### PR TITLE
Fix trusted proxy configuration when config is cached

### DIFF
--- a/app/Http/Middleware/TrustConfiguredProxies.php
+++ b/app/Http/Middleware/TrustConfiguredProxies.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Illuminate\Http\Middleware\TrustProxies;
+use Illuminate\Http\Request;
+
+class TrustConfiguredProxies extends TrustProxies
+{
+    protected function proxies(): array|string|null
+    {
+        return config('trustedproxy.proxies');
+    }
+
+    protected function headers(): int
+    {
+        return Request::HEADER_X_FORWARDED_FOR
+            | Request::HEADER_X_FORWARDED_PORT
+            | Request::HEADER_X_FORWARDED_PROTO
+            | Request::HEADER_X_FORWARDED_PREFIX;
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -7,6 +7,7 @@ use App\Http\Middleware\EnsureUserIsActive;
 use App\Http\Middleware\RequireEmailAddress;
 use App\Http\Middleware\RequireMailHealthy;
 use App\Http\Middleware\RequireTwoFactor;
+use App\Http\Middleware\TrustConfiguredProxies;
 use App\Models\TrustedDevice;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
@@ -40,30 +41,9 @@ return Application::configure(basePath: dirname(__DIR__))
         // anything that has to read it back verbatim.
         $middleware->encryptCookies(except: [TrustedDevice::COOKIE]);
 
-        // Honor X-Forwarded-* from a TLS-terminating reverse proxy (Traefik,
-        // Caddy, nginx-proxy-manager, Cloudflare, …). Without this Laravel
-        // sees the plain-HTTP hop from the proxy and generates http:// asset
-        // URLs, which browsers block as mixed content on an https page.
-        //
-        // Deliberately NOT '*': headers are only honored when the immediate
-        // peer is a private/loopback address (Docker bridges, same-box nginx).
-        // A client hitting an exposed port directly from a public address
-        // cannot forge X-Forwarded-For into the audit logs. Override with
-        // TRUSTED_PROXIES (comma-separated CIDRs, or '*') when your proxy
-        // reaches the app from a public address.
-        //
-        // X-Forwarded-Host is intentionally excluded from the trusted set:
-        // proxies pass the original Host header through anyway, and honoring
-        // XFH would let a forged header poison generated absolute URLs.
-        $middleware->trustProxies(
-            at: array_map('trim', explode(',', (string) env(
-                'TRUSTED_PROXIES',
-                '127.0.0.1,::1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16',
-            ))),
-            headers: Request::HEADER_X_FORWARDED_FOR
-                | Request::HEADER_X_FORWARDED_PORT
-                | Request::HEADER_X_FORWARDED_PROTO
-                | Request::HEADER_X_FORWARDED_PREFIX,
+        $middleware->replace(
+            \Illuminate\Http\Middleware\TrustProxies::class,
+            TrustConfiguredProxies::class,
         );
     })
     ->withExceptions(function (Exceptions $exceptions): void {

--- a/config/trustedproxy.php
+++ b/config/trustedproxy.php
@@ -1,0 +1,13 @@
+<?php
+
+return [
+    // TLS proxies must be explicitly trusted. The default covers local and
+    // private Docker/LAN proxy hops; set TRUSTED_PROXIES for another topology.
+    'proxies' => array_values(array_filter(array_map(
+        'trim',
+        explode(',', (string) env(
+            'TRUSTED_PROXIES',
+            '127.0.0.1,::1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16',
+        )),
+    ))),
+];

--- a/tests/Feature/ExampleTest.php
+++ b/tests/Feature/ExampleTest.php
@@ -10,6 +10,26 @@ it('shows the login page', function () {
     $this->get('/login')->assertOk()->assertSee('Sign In');
 });
 
+it('uses forwarded HTTPS only from a trusted proxy', function () {
+    $trusted = $this->withServerVariables([
+        'HTTP_HOST' => 'cortendesk.test',
+        'REMOTE_ADDR' => '127.0.0.1',
+        'HTTP_X_FORWARDED_PROTO' => 'https',
+    ])->get('/login');
+
+    $trusted->assertOk()
+        ->assertSee('action="https://cortendesk.test/login"', escape: false);
+
+    $untrusted = $this->withServerVariables([
+        'HTTP_HOST' => 'cortendesk.test',
+        'REMOTE_ADDR' => '192.0.2.1',
+        'HTTP_X_FORWARDED_PROTO' => 'https',
+    ])->get('/login');
+
+    $untrusted->assertOk()
+        ->assertSee('action="http://cortendesk.test/login"', escape: false);
+});
+
 it('renders the overview dashboard with charts and live tiles', function () {
     $user = User::create(['username' => 'dash', 'password' => 'secret-password']);
 


### PR DESCRIPTION
## Summary
- resolve trusted proxy settings through Laravel configuration at request time
- preserve the existing restricted forwarded-header policy without trusting forwarded hosts
- add trusted and untrusted forwarded-TLS regression coverage

## Why
The current bootstrap reads `TRUSTED_PROXIES` directly. When Laravel configuration is cached, a value placed in `.env` is not loaded, so the intended proxy setting can be lost.

## Validation
- `git diff --check origin/main..HEAD`
- Local Pest execution unavailable on this host because PHP/vendor dependencies are not installed.
