### PR TITLE
feat: add sortable device inventory

### DIFF
--- a/app/Livewire/DeviceList.php
+++ b/app/Livewire/DeviceList.php
@@ -44,10 +44,31 @@ class DeviceList extends Component
     /** What the table showed before it was configurable — and still the default. */
     public const DEFAULT_COLUMNS = ['device', 'alias', 'group', 'owner', 'version', 'last_seen'];
 
+    /**
+     * Sort keys accepted from the browser. Values are fixed SQL identifiers,
+     * never request data, so sortBy() cannot turn a Livewire payload into SQL.
+     */
+    public const SORTABLE = [
+        'id' => 'devices.rustdesk_id',
+        'device' => 'devices.hostname',
+        'alias' => 'devices.alias',
+        'group' => '__group__',
+        'owner' => '__owner__',
+        'version' => 'devices.version',
+        'first_seen' => 'devices.created_at',
+        'last_seen' => 'devices.last_online_at',
+        'status' => '__presence__',
+    ];
+
     /** Keys of the columns currently shown (checkbox array binding). */
     public array $columns = [];
 
     public bool $columnsOpen = false;
+
+    /** Current deterministic device ordering (issue #27). */
+    public string $sortField = 'last_seen';
+
+    public string $sortDirection = 'desc';
 
     /**
      * Selected device ids for bulk actions (issue #15). Checkbox values arrive
@@ -117,6 +138,61 @@ class DeviceList extends Component
         $this->columns = is_array($saved)
             ? array_values(array_intersect(array_keys(self::COLUMNS), $saved))
             : self::DEFAULT_COLUMNS;
+
+        $savedSort = (string) (auth()->user()?->devices_sort ?? '');
+        $savedDirection = (string) (auth()->user()?->devices_sort_direction ?? '');
+        if ($this->canSortBy($savedSort)) {
+            $this->sortField = $savedSort;
+            $this->sortDirection = in_array($savedDirection, ['asc', 'desc'], true)
+                ? $savedDirection
+                : 'asc';
+        }
+    }
+
+    /** Select a column, or reverse it when the current column is selected. */
+    public function sortBy(string $field): void
+    {
+        if (! $this->canSortBy($field)) {
+            return;
+        }
+
+        if ($this->sortField === $field) {
+            $this->sortDirection = $this->sortDirection === 'asc' ? 'desc' : 'asc';
+        } else {
+            $this->sortField = $field;
+            $this->sortDirection = 'asc';
+        }
+
+        auth()->user()->forceFill([
+            'devices_sort' => $this->sortField,
+            'devices_sort_direction' => $this->sortDirection,
+        ])->save();
+
+        $this->resetPage();
+        $this->clearSelection();
+    }
+
+    /** Choose a field on mobile without also reversing its direction. */
+    public function selectSort(string $field): void
+    {
+        if (! $this->canSortBy($field) || $this->sortField === $field) {
+            return;
+        }
+
+        $this->sortField = $field;
+        $this->sortDirection = 'asc';
+        auth()->user()->forceFill([
+            'devices_sort' => $this->sortField,
+            'devices_sort_direction' => $this->sortDirection,
+        ])->save();
+        $this->resetPage();
+        $this->clearSelection();
+    }
+
+    private function canSortBy(string $field): bool
+    {
+        return isset(self::SORTABLE[$field])
+            && ($field !== 'owner' || auth()->user()?->is_admin);
     }
 
     /** Persist the column selection so it survives sign-out (issue #16). */
@@ -538,7 +614,7 @@ class DeviceList extends Component
      */
     private function filteredQuery(User $user)
     {
-        return Device::query()
+        $query = Device::query()
             ->visibleTo($user)
             ->with(['group', 'user'])
             ->when($this->trashed, fn ($q) => $q->onlyTrashed())
@@ -556,9 +632,48 @@ class DeviceList extends Component
             ->when(! $this->trashed && $this->status === 'offline', fn ($q) => $q->offline())
             ->when($this->group > 0, fn ($q) => $q->where('device_group_id', $this->group))
             ->when($this->owner === -1, fn ($q) => $q->whereNull('user_id'))
-            ->when($this->owner > 0, fn ($q) => $q->where('user_id', $this->owner))
-            ->orderByRaw('last_online_at IS NULL')
-            ->orderByDesc('last_online_at');
+            ->when($this->owner > 0, fn ($q) => $q->where('user_id', $this->owner));
+
+        return $this->applySort($query);
+    }
+
+    /** Apply a validated sort with nulls last and a stable ID tie-breaker. */
+    private function applySort($query)
+    {
+        $field = $this->canSortBy($this->sortField) ? $this->sortField : 'last_seen';
+        $direction = in_array($this->sortDirection, ['asc', 'desc'], true)
+            ? $this->sortDirection
+            : 'desc';
+
+        if ($field === 'status') {
+            $cutoff = now()->subSeconds(Device::onlineWindow());
+            $query->orderByRaw(
+                "CASE WHEN devices.last_online_at > ? THEN 1 ELSE 0 END {$direction}",
+                [$cutoff],
+            );
+        } elseif ($field === 'group') {
+            $name = DeviceGroup::query()
+                ->select('name')
+                ->whereColumn('device_groups.id', 'devices.device_group_id');
+            $query->orderByRaw('devices.device_group_id IS NULL')
+                ->orderBy($name, $direction);
+        } elseif ($field === 'owner') {
+            $username = User::query()
+                ->select('username')
+                ->whereColumn('users.id', 'devices.user_id');
+            $query->orderByRaw('devices.user_id IS NULL')
+                ->orderBy($username, $direction);
+        } else {
+            $column = self::SORTABLE[$field];
+            if (in_array($field, ['device', 'alias', 'version'], true)) {
+                $query->orderByRaw("CASE WHEN {$column} IS NULL OR {$column} = '' THEN 1 ELSE 0 END");
+            } elseif ($field === 'last_seen') {
+                $query->orderByRaw("{$column} IS NULL");
+            }
+            $query->orderBy($column, $direction);
+        }
+
+        return $query->orderBy('devices.rustdesk_id');
     }
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -2,7 +2,6 @@
 
 namespace App\Models;
 
-use App\Models\AddressBook;
 use App\Support\Permissions;
 use Database\Factories\UserFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
@@ -17,7 +16,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 
-#[Fillable(['username', 'name', 'email', 'password', 'avatar', 'is_admin', 'role_id', 'is_active', 'note', 'devices_columns'])]
+#[Fillable(['username', 'name', 'email', 'password', 'avatar', 'is_admin', 'role_id', 'is_active', 'note', 'devices_columns', 'devices_sort', 'devices_sort_direction'])]
 #[Hidden(['password', 'remember_token', 'totp_secret'])]
 class User extends Authenticatable
 {

--- a/database/migrations/2026_08_12_000010_add_device_sort_to_users_table.php
+++ b/database/migrations/2026_08_12_000010_add_device_sort_to_users_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            // Null preserves the exact pre-#27 default: most recently seen first.
+            $table->string('devices_sort', 32)->nullable()->after('devices_columns');
+            $table->string('devices_sort_direction', 4)->nullable()->after('devices_sort');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn(['devices_sort', 'devices_sort_direction']);
+        });
+    }
+};

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true">
+    <testsuites>
+        <testsuite name="Feature">
+            <directory>tests/Feature</directory>
+        </testsuite>
+    </testsuites>
+    <source>
+        <include>
+            <directory>app</directory>
+        </include>
+    </source>
+    <php>
+        <env name="APP_ENV" value="testing"/>
+        <env name="APP_KEY" value="base64:RS1QLhuuYPHOBOwym/pch/YMJbc+FyZrwFNZHaogPqQ="/>
+        <env name="BCRYPT_ROUNDS" value="4"/>
+        <env name="CACHE_STORE" value="array"/>
+        <env name="DB_CONNECTION" value="sqlite"/>
+        <env name="DB_DATABASE" value=":memory:"/>
+        <env name="MAIL_MAILER" value="array"/>
+        <env name="QUEUE_CONNECTION" value="sync"/>
+        <env name="SESSION_DRIVER" value="array"/>
+    </php>
+</phpunit>

--- a/resources/views/livewire/device-list.blade.php
+++ b/resources/views/livewire/device-list.blade.php
@@ -50,6 +50,22 @@
                     @endforeach
                 </select>
             @endif
+            <select class="form-select rd-toolbar-filter d-md-none"
+                    wire:change="selectSort($event.target.value)" aria-label="Sort devices by">
+                <option value="id" @selected($sortField === 'id')>Sort: ID</option>
+                <option value="device" @selected($sortField === 'device')>Sort: Device</option>
+                <option value="alias" @selected($sortField === 'alias')>Sort: Alias</option>
+                <option value="group" @selected($sortField === 'group')>Sort: Group</option>
+                @if (auth()->user()?->is_admin)<option value="owner" @selected($sortField === 'owner')>Sort: Owner</option>@endif
+                <option value="version" @selected($sortField === 'version')>Sort: Version</option>
+                <option value="first_seen" @selected($sortField === 'first_seen')>Sort: First seen</option>
+                <option value="last_seen" @selected($sortField === 'last_seen')>Sort: Last seen</option>
+                <option value="status" @selected($sortField === 'status')>Sort: Status</option>
+            </select>
+            <button type="button" class="btn btn-outline-light d-md-none" wire:click="sortBy('{{ $sortField }}')"
+                    aria-label="Reverse device sort order" title="Reverse sort order">
+                <i class="{{ $sortDirection === 'asc' ? 'ri-sort-asc' : 'ri-sort-desc' }}"></i>
+            </button>
             <div class="rd-toolbar-actions">
                 <button type="button" class="btn btn-outline-light" wire:click="resetFilters">Reset</button>
                 @if ($trashed)
@@ -157,20 +173,22 @@
                             @endif
                         @endunless
                     </th>
-                    <th>ID</th>
-                    @if ($cols['device'])<th>Device</th>@endif
-                    @if ($cols['alias'])<th>Alias</th>@endif
-                    @if ($cols['group'])<th>Group</th>@endif
-                    @if ($cols['owner'])<th>Owner</th>@endif
-                    @if ($cols['version'])<th>Version</th>@endif
+                    <th aria-sort="{{ $sortField === 'id' ? ($sortDirection === 'asc' ? 'ascending' : 'descending') : 'none' }}">
+                        <button type="button" class="btn btn-link text-reset p-0 text-decoration-none" wire:click="sortBy('id')">ID @if ($sortField === 'id')<i class="{{ $sortDirection === 'asc' ? 'ri-arrow-up-s-line' : 'ri-arrow-down-s-line' }}"></i>@endif</button>
+                    </th>
+                    @if ($cols['device'])<th aria-sort="{{ $sortField === 'device' ? ($sortDirection === 'asc' ? 'ascending' : 'descending') : 'none' }}"><button type="button" class="btn btn-link text-reset p-0 text-decoration-none" wire:click="sortBy('device')">Device @if ($sortField === 'device')<i class="{{ $sortDirection === 'asc' ? 'ri-arrow-up-s-line' : 'ri-arrow-down-s-line' }}"></i>@endif</button></th>@endif
+                    @if ($cols['alias'])<th aria-sort="{{ $sortField === 'alias' ? ($sortDirection === 'asc' ? 'ascending' : 'descending') : 'none' }}"><button type="button" class="btn btn-link text-reset p-0 text-decoration-none" wire:click="sortBy('alias')">Alias @if ($sortField === 'alias')<i class="{{ $sortDirection === 'asc' ? 'ri-arrow-up-s-line' : 'ri-arrow-down-s-line' }}"></i>@endif</button></th>@endif
+                    @if ($cols['group'])<th aria-sort="{{ $sortField === 'group' ? ($sortDirection === 'asc' ? 'ascending' : 'descending') : 'none' }}"><button type="button" class="btn btn-link text-reset p-0 text-decoration-none" wire:click="sortBy('group')">Group @if ($sortField === 'group')<i class="{{ $sortDirection === 'asc' ? 'ri-arrow-up-s-line' : 'ri-arrow-down-s-line' }}"></i>@endif</button></th>@endif
+                    @if ($cols['owner'])<th aria-sort="{{ $sortField === 'owner' ? ($sortDirection === 'asc' ? 'ascending' : 'descending') : 'none' }}"><button type="button" class="btn btn-link text-reset p-0 text-decoration-none" wire:click="sortBy('owner')">Owner @if ($sortField === 'owner')<i class="{{ $sortDirection === 'asc' ? 'ri-arrow-up-s-line' : 'ri-arrow-down-s-line' }}"></i>@endif</button></th>@endif
+                    @if ($cols['version'])<th aria-sort="{{ $sortField === 'version' ? ($sortDirection === 'asc' ? 'ascending' : 'descending') : 'none' }}"><button type="button" class="btn btn-link text-reset p-0 text-decoration-none" wire:click="sortBy('version')">Version @if ($sortField === 'version')<i class="{{ $sortDirection === 'asc' ? 'ri-arrow-up-s-line' : 'ri-arrow-down-s-line' }}"></i>@endif</button></th>@endif
                     @if ($cols['username'])<th>User</th>@endif
                     @if ($cols['ip'])<th>IP</th>@endif
                     @if ($cols['cpu'])<th>CPU</th>@endif
                     @if ($cols['memory'])<th>Memory</th>@endif
                     @if ($cols['uuid'])<th>UUID</th>@endif
-                    @if ($cols['first_seen'])<th>First Seen</th>@endif
-                    @if ($cols['last_seen'])<th>Last Seen</th>@endif
-                    <th>Status</th>
+                    @if ($cols['first_seen'])<th aria-sort="{{ $sortField === 'first_seen' ? ($sortDirection === 'asc' ? 'ascending' : 'descending') : 'none' }}"><button type="button" class="btn btn-link text-reset p-0 text-decoration-none" wire:click="sortBy('first_seen')">First Seen @if ($sortField === 'first_seen')<i class="{{ $sortDirection === 'asc' ? 'ri-arrow-up-s-line' : 'ri-arrow-down-s-line' }}"></i>@endif</button></th>@endif
+                    @if ($cols['last_seen'])<th aria-sort="{{ $sortField === 'last_seen' ? ($sortDirection === 'asc' ? 'ascending' : 'descending') : 'none' }}"><button type="button" class="btn btn-link text-reset p-0 text-decoration-none" wire:click="sortBy('last_seen')">Last Seen @if ($sortField === 'last_seen')<i class="{{ $sortDirection === 'asc' ? 'ri-arrow-up-s-line' : 'ri-arrow-down-s-line' }}"></i>@endif</button></th>@endif
+                    <th aria-sort="{{ $sortField === 'status' ? ($sortDirection === 'asc' ? 'ascending' : 'descending') : 'none' }}"><button type="button" class="btn btn-link text-reset p-0 text-decoration-none" wire:click="sortBy('status')">Status @if ($sortField === 'status')<i class="{{ $sortDirection === 'asc' ? 'ri-arrow-up-s-line' : 'ri-arrow-down-s-line' }}"></i>@endif</button></th>
                     <th class="text-end">Action</th>
                 </tr>
                 </thead>

--- a/tests/Feature/DeviceSortingTest.php
+++ b/tests/Feature/DeviceSortingTest.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Livewire\DeviceList;
+use App\Models\Device;
+use App\Models\DeviceGroup;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class DeviceSortingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_sorting_by_alias_toggles_direction_and_keeps_nulls_last(): void
+    {
+        $admin = User::factory()->admin()->create();
+        $this->device('100', alias: 'Zulu', seenAt: now()->subMinute());
+        $this->device('200', alias: null, seenAt: now());
+        $this->device('300', alias: 'Alpha', seenAt: now()->subMinutes(2));
+
+        $component = Livewire::actingAs($admin)
+            ->test(DeviceList::class)
+            ->call('sortBy', 'alias')
+            ->assertSet('sortField', 'alias')
+            ->assertSet('sortDirection', 'asc')
+            ->assertViewHas('devices', fn ($devices) => $devices->pluck('rustdesk_id')->all() === ['300', '100', '200']);
+
+        $component
+            ->call('sortBy', 'alias')
+            ->assertSet('sortDirection', 'desc')
+            ->assertViewHas('devices', fn ($devices) => $devices->pluck('rustdesk_id')->all() === ['100', '300', '200']);
+    }
+
+    public function test_sorting_supports_group_owner_status_and_last_seen(): void
+    {
+        $admin = User::factory()->admin()->create();
+        $alphaGroup = DeviceGroup::create(['name' => 'Alpha']);
+        $zuluGroup = DeviceGroup::create(['name' => 'Zulu']);
+        $amy = User::factory()->create(['username' => 'amy']);
+        $zoe = User::factory()->create(['username' => 'zoe']);
+
+        $this->device('100', group: $zuluGroup, owner: $amy, seenAt: now()->subMinutes(10));
+        $this->device('200', group: $alphaGroup, owner: $zoe, seenAt: now());
+        $this->device('300', group: null, owner: null, seenAt: null);
+
+        Livewire::actingAs($admin)
+            ->test(DeviceList::class)
+            ->call('sortBy', 'group')
+            ->assertViewHas('devices', fn ($devices) => $devices->pluck('rustdesk_id')->all() === ['200', '100', '300'])
+            ->call('sortBy', 'owner')
+            ->assertViewHas('devices', fn ($devices) => $devices->pluck('rustdesk_id')->all() === ['100', '200', '300'])
+            ->call('sortBy', 'status')
+            ->assertViewHas('devices', fn ($devices) => $devices->pluck('rustdesk_id')->all() === ['100', '300', '200'])
+            ->call('sortBy', 'status')
+            ->assertViewHas('devices', fn ($devices) => $devices->pluck('rustdesk_id')->all() === ['200', '100', '300'])
+            ->call('sortBy', 'last_seen')
+            ->assertViewHas('devices', fn ($devices) => $devices->pluck('rustdesk_id')->all() === ['100', '200', '300']);
+    }
+
+    public function test_sort_preference_survives_a_fresh_component_mount(): void
+    {
+        $admin = User::factory()->admin()->create();
+        $this->device('100', alias: 'Zulu');
+        $this->device('200', alias: 'Alpha');
+
+        Livewire::actingAs($admin)
+            ->test(DeviceList::class)
+            ->call('sortBy', 'alias')
+            ->call('sortBy', 'alias');
+
+        $admin->refresh();
+        $this->assertSame('alias', $admin->devices_sort);
+        $this->assertSame('desc', $admin->devices_sort_direction);
+
+        Livewire::actingAs($admin)
+            ->test(DeviceList::class)
+            ->assertSet('sortField', 'alias')
+            ->assertSet('sortDirection', 'desc')
+            ->assertViewHas('devices', fn ($devices) => $devices->pluck('rustdesk_id')->all() === ['100', '200']);
+    }
+
+    public function test_default_sort_remains_last_seen_descending_and_export_uses_the_same_order(): void
+    {
+        $admin = User::factory()->admin()->create();
+        $this->device('100', seenAt: now()->subMinutes(2));
+        $this->device('200', seenAt: now());
+        $this->device('300', seenAt: null);
+
+        $component = Livewire::actingAs($admin)
+            ->test(DeviceList::class)
+            ->assertViewHas('devices', fn ($devices) => $devices->pluck('rustdesk_id')->all() === ['200', '100', '300']);
+
+        $component->call('sortBy', 'id');
+        $response = $component->instance()->exportCsv();
+        ob_start();
+        $response->sendContent();
+        $csv = (string) ob_get_clean();
+        $this->assertStringContainsString('1,100,', $csv);
+        $this->assertLessThan(strpos($csv, ',200,'), strpos($csv, ',100,'));
+    }
+
+    public function test_non_admin_cannot_select_owner_sort_and_unknown_fields_are_rejected(): void
+    {
+        $user = User::factory()->create();
+
+        Livewire::actingAs($user)
+            ->test(DeviceList::class)
+            ->call('sortBy', 'owner')
+            ->assertSet('sortField', 'last_seen')
+            ->call('sortBy', 'drop table devices')
+            ->assertSet('sortField', 'last_seen');
+    }
+
+    private function device(
+        string $id,
+        ?string $alias = null,
+        ?DeviceGroup $group = null,
+        ?User $owner = null,
+        $seenAt = null,
+    ): Device {
+        return Device::create([
+            'rustdesk_id' => $id,
+            'uuid' => 'uuid-'.$id,
+            'alias' => $alias,
+            'device_group_id' => $group?->id,
+            'user_id' => $owner?->id,
+            'last_online_at' => $seenAt,
+        ]);
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Tests;
+
+use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
+
+abstract class TestCase extends BaseTestCase {}


### PR DESCRIPTION
## Summary

- Adds sortable device inventory headings on desktop and compact sorting controls on mobile.
- Persists each user's selected sort field and direction.
- Keeps blank values last and adds a stable RustDesk ID tie-breaker so rows stop jumping during refreshes.
- Applies the selected order to CSV exports while preserving the current last-seen default.

## Testing

- `php artisan test --compact` — 5 tests, 20 assertions passed
- `php artisan view:cache`
- Pint checks for all changed PHP files
- `git diff --check origin/main...HEAD`

## Compatibility and scope

- Existing users retain the current last-seen-descending default until they choose another order.
- Sorting remains constrained to a fixed allowlist; non-admin users cannot select owner sorting.
- This PR is limited to device inventory ordering and its focused test harness.

Refs #27
