### PR TITLE
feat: add configurable Apprise notifications

### DIFF
--- a/app/Console/Commands/CheckDeviceNotifications.php
+++ b/app/Console/Commands/CheckDeviceNotifications.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Device;
+use App\Services\AppriseNotifications;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Cache;
+
+/**
+ * Tracks presence transitions for notifications. Device rows intentionally do
+ * not carry notification state: cache keys expire after a bounded retention,
+ * preserve existing schema semantics, and make disabling/re-enabling alerts
+ * innocuous. The online endpoint also clears an offline marker immediately,
+ * which means recovery is prompt rather than waiting for this minute sweep.
+ */
+class CheckDeviceNotifications extends Command
+{
+    public const OFFLINE_MARKER_PREFIX = 'apprise:device-offline:';
+
+    private const MARKER_TTL_DAYS = 30;
+
+    protected $signature = 'cortendesk:check-device-notifications';
+
+    protected $description = 'Detect device offline/recovery transitions for Apprise notifications';
+
+    public function handle(AppriseNotifications $notifications): int
+    {
+        if (! $notifications->isEnabledFor('device.offline') && ! $notifications->isEnabledFor('device.online')) {
+            $this->info('Device presence notifications are disabled.');
+
+            return self::SUCCESS;
+        }
+
+        $offline = 0;
+        $recovered = 0;
+
+        Device::query()->approved()->orderBy('id')->each(function (Device $device) use ($notifications, &$offline, &$recovered): void {
+            $marker = self::marker($device->rustdesk_id);
+
+            if (! $device->isOnline()) {
+                if (Cache::add($marker, true, now()->addDays(self::MARKER_TTL_DAYS))) {
+                    $notifications->send(
+                        'device.offline',
+                        'Device offline',
+                        self::deviceLabel($device).' stopped heartbeating.',
+                        'device:'.$device->rustdesk_id,
+                        $device,
+                    );
+                    $offline++;
+                }
+
+                return;
+            }
+
+            if (Cache::pull($marker)) {
+                $notifications->send(
+                    'device.online',
+                    'Device recovered',
+                    self::deviceLabel($device).' is online again.',
+                    'device:'.$device->rustdesk_id,
+                    $device,
+                );
+                $recovered++;
+            }
+        });
+
+        $this->info("Detected {$offline} offline and {$recovered} recovered device transition(s).");
+
+        return self::SUCCESS;
+    }
+
+    /** Notify recovery on the first heartbeat after the scheduled sweep marked a device offline. */
+    public static function reportOnline(Device $device, AppriseNotifications $notifications): void
+    {
+        if ($device->status !== Device::STATUS_ACTIVE || ! Cache::pull(self::marker($device->rustdesk_id))) {
+            return;
+        }
+
+        $notifications->send(
+            'device.online',
+            'Device recovered',
+            self::deviceLabel($device).' is online again.',
+            'device:'.$device->rustdesk_id,
+            $device,
+        );
+    }
+
+    public static function marker(string $rustdeskId): string
+    {
+        return self::OFFLINE_MARKER_PREFIX.sha1($rustdeskId);
+    }
+
+    public static function deviceLabel(Device $device): string
+    {
+        $name = trim((string) ($device->alias ?: $device->hostname));
+
+        return $name === '' ? 'Device '.$device->rustdesk_id : $name.' ('.$device->rustdesk_id.')';
+    }
+}

--- a/app/Console/Commands/PruneLogs.php
+++ b/app/Console/Commands/PruneLogs.php
@@ -24,6 +24,7 @@ class PruneLogs extends Command
         'login_logs',
         'alarm_logs',
         'console_audits',
+        'notification_deliveries',
     ];
 
     private const CHUNK = 10_000;

--- a/app/Http/Controllers/Api/AuditController.php
+++ b/app/Http/Controllers/Api/AuditController.php
@@ -6,6 +6,8 @@ use App\Http\Controllers\Controller;
 use App\Models\AlarmLog;
 use App\Models\AuditConnection;
 use App\Models\AuditFileTransfer;
+use App\Models\Device;
+use App\Services\AppriseNotifications;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 
@@ -111,13 +113,33 @@ class AuditController extends Controller
             return response()->json((object) []);
         }
 
-        AlarmLog::create([
+        $alarm = AlarmLog::create([
             'rustdesk_id' => $id,
             'uuid' => (string) $request->input('uuid', ''),
             'typ' => (int) $request->input('typ', 0),
             'info' => (string) $request->input('info', ''),
             'conn_id' => (int) $request->input('conn_id', 0) ?: null,
         ]);
+
+        $notifications = app(AppriseNotifications::class);
+        $device = Device::query()->where('rustdesk_id', $id)->first();
+        $notifications->send(
+            'security.alarm',
+            $alarm->typeLabel(),
+            'Device '.$id.' reported a security alarm.',
+            'alarm:'.$alarm->id,
+            $device,
+        );
+
+        if ($alarm->typ === 1) {
+            $notifications->send(
+                'remote_connection.failure',
+                'Repeated remote connection failures',
+                'Device '.$id.' reported more than 30 failed connection attempts.',
+                'device:'.$id,
+                $device,
+            );
+        }
 
         return response()->json((object) []);
     }

--- a/app/Http/Controllers/Api/ClientAuthController.php
+++ b/app/Http/Controllers/Api/ClientAuthController.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\Controller;
 use App\Models\ClientToken;
 use App\Models\LoginLog;
 use App\Models\User;
+use App\Services\AppriseNotifications;
 use App\Services\OidcService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -71,6 +72,13 @@ class ClientAuthController extends Controller
         ]);
 
         if (! $ok) {
+            app(AppriseNotifications::class)->send(
+                'console.login_failed',
+                'Failed console login',
+                'A RustDesk client sign-in attempt failed.',
+                'client-login:'.sha1(mb_strtolower($username).'|'.$request->ip()),
+            );
+
             // The client shows this message verbatim (after i18n lookup).
             return response()->json(['error' => 'Wrong credentials']);
         }

--- a/app/Http/Controllers/Api/SyncController.php
+++ b/app/Http/Controllers/Api/SyncController.php
@@ -2,10 +2,12 @@
 
 namespace App\Http\Controllers\Api;
 
+use App\Console\Commands\CheckDeviceNotifications;
 use App\Http\Controllers\Controller;
 use App\Models\AuditConnection;
 use App\Models\Device;
 use App\Models\Strategy;
+use App\Services\AppriseNotifications;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 
@@ -57,6 +59,7 @@ class SyncController extends Controller
         }
 
         $device->forceFill($update)->saveQuietly();
+        CheckDeviceNotifications::reportOnline($device, app(AppriseNotifications::class));
 
         $response = [];
 
@@ -143,15 +146,26 @@ class SyncController extends Controller
             // Deployment approval gate (PLAN B3): when enabled, a first-seen
             // id+uuid is quarantined as 'pending' — registered but excluded from
             // scoping/address books/group tab/device list until an operator
-            // approves it. The plain-text ack stays identical so the client sees
-            // no difference (heartbeat/sysinfo remain fully transparent).
+            // approves it on the Devices → Pending tab. The plain-text ack stays
+            // identical so the client sees no difference.
             $attributes['status'] = Device::approvalGateEnabled()
                 ? Device::STATUS_PENDING
                 : Device::STATUS_ACTIVE;
 
-            Device::create(['rustdesk_id' => $id] + $attributes);
+            $device = Device::create(['rustdesk_id' => $id] + $attributes);
+
+            if ($device->isPending()) {
+                app(AppriseNotifications::class)->send(
+                    'device.pending_approval',
+                    'Device pending approval',
+                    CheckDeviceNotifications::deviceLabel($device).' is awaiting approval.',
+                    'device:'.$device->rustdesk_id,
+                    $device,
+                );
+            }
         } else {
             $device->update($attributes);
+            CheckDeviceNotifications::reportOnline($device, app(AppriseNotifications::class));
         }
 
         return response('SYSINFO_UPDATED');

--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -7,6 +7,7 @@ use App\Models\AlarmLog;
 use App\Models\LoginLog;
 use App\Models\TrustedDevice;
 use App\Models\User;
+use App\Services\AppriseNotifications;
 use App\Services\MailSettings;
 use App\Services\OidcService;
 use App\Support\LoginEmailVerification;
@@ -111,6 +112,12 @@ class AuthController extends Controller
         ]);
 
         if (! $ok || ! $user) {
+            app(AppriseNotifications::class)->send(
+                'console.login_failed',
+                'Failed console login',
+                'A web-console sign-in attempt failed.',
+                'web-login:'.sha1(mb_strtolower($credentials['username']).'|'.$ip),
+            );
             RateLimiter::hit($accountKey, self::DECAY);
             RateLimiter::hit($addressKey, self::DECAY);
 

--- a/app/Livewire/SettingsPage.php
+++ b/app/Livewire/SettingsPage.php
@@ -4,13 +4,18 @@ namespace App\Livewire;
 
 use App\Livewire\Concerns\AuthorizesConsole;
 use App\Models\ConsoleAudit;
+use App\Models\Device;
+use App\Models\DeviceGroup;
+use App\Models\NotificationDelivery;
 use App\Models\Setting;
 use App\Models\UserGroup;
+use App\Services\AppriseNotifications;
 use App\Services\MailSettings;
 use App\Services\OidcService;
 use App\Support\LoginEmailVerification;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Crypt;
+use Illuminate\Validation\ValidationException;
 use Livewire\Attributes\Url;
 use Livewire\Component;
 
@@ -114,6 +119,43 @@ class SettingsPage extends Component
     /** Emailed 6-digit code on a browser the console has not seen before. */
     public bool $emailLoginVerification = false;
 
+    // ---- Apprise notifications -------------------------------------------
+
+    public bool $appriseEnabled = false;
+
+    /** Write-only saved transport fields; blank preserves encrypted values. */
+    public string $appriseEndpoint = '';
+
+    public string $appriseMode = 'config';
+
+    public string $appriseConfigKey = '';
+
+    public string $appriseUrls = '';
+
+    public bool $appriseEndpointSet = false;
+
+    public bool $appriseConfigKeySet = false;
+
+    public bool $appriseUrlsSet = false;
+
+    public int $appriseCooldownMinutes = 15;
+
+    /** @var array<string, bool> */
+    public array $appriseEvents = [];
+
+    /** @var array<string, string> */
+    public array $appriseScopes = [];
+
+    /** @var array<string, array<int, int|string>> */
+    public array $appriseScopeGroups = [];
+
+    /** @var array<string, array<int, int|string>> */
+    public array $appriseScopeDevices = [];
+
+    public string $appriseTestMessage = '';
+
+    public bool $appriseTestOk = false;
+
     public int $emailTrustedDeviceDays = 30;
 
     public bool $saved = false;
@@ -167,6 +209,20 @@ class SettingsPage extends Component
         $this->emailLoginVerification = Setting::get('email_login_verification', '0') === '1';
         $this->emailTrustedDeviceDays = (int) (Setting::get('email_trusted_device_days', '30') ?: 30);
 
+        $this->appriseEnabled = Setting::get('apprise_enabled', '0') === '1';
+        $this->appriseMode = Setting::get('apprise_delivery_mode', 'config') === 'urls' ? 'urls' : 'config';
+        $this->appriseEndpointSet = trim((string) Setting::get('apprise_endpoint', '')) !== '';
+        $this->appriseConfigKeySet = trim((string) Setting::get('apprise_config_key', '')) !== '';
+        $this->appriseUrlsSet = trim((string) Setting::get('apprise_urls', '')) !== '';
+        $this->appriseCooldownMinutes = (int) (Setting::get('apprise_cooldown_minutes', '15') ?: 15);
+        foreach (AppriseNotifications::EVENTS as $event => $_label) {
+            $suffix = str_replace('.', '_', $event);
+            $this->appriseEvents[$suffix] = Setting::get('apprise_event_'.$suffix, '0') === '1';
+            $this->appriseScopes[$suffix] = Setting::get('apprise_scope_'.$suffix, 'all') === 'selected' ? 'selected' : 'all';
+            $this->appriseScopeGroups[$suffix] = json_decode((string) Setting::get('apprise_scope_groups_'.$suffix, '[]'), true) ?: [];
+            $this->appriseScopeDevices[$suffix] = json_decode((string) Setting::get('apprise_scope_devices_'.$suffix, '[]'), true) ?: [];
+        }
+
         $stored = json_decode(Setting::get('relay_servers', '') ?: '[]', true);
         $this->relayServers = is_array($stored) ? array_values(array_map(fn ($r) => [
             'address' => (string) ($r['address'] ?? ''),
@@ -204,6 +260,7 @@ class SettingsPage extends Component
         return match (true) {
             str_starts_with($root, 'oidc') => 'sso',
             str_starts_with($root, 'smtp') => 'email',
+            str_starts_with($root, 'apprise') => 'notifications',
             $root === 'logRetentionDays' => 'maintenance',
             in_array($root, ['twoFactorRequired', 'twoFactorRequiredAdmins', 'emailLoginVerification', 'emailTrustedDeviceDays'], true) => 'security',
             in_array($root, ['idServer', 'relayServer', 'publicKey', 'onlineWindow', 'rdgenUrl', 'relayServers', 'requireDeviceApproval'], true) => 'server',
@@ -243,8 +300,13 @@ class SettingsPage extends Component
                 'smtpFromAddress' => 'nullable|email|max:255',
                 'smtpFromName' => 'nullable|string|max:64',
                 'emailTrustedDeviceDays' => 'required|integer|min:1|max:365',
+                'appriseEndpoint' => 'nullable|url:http,https|max:2048',
+                'appriseMode' => 'required|in:config,urls',
+                'appriseConfigKey' => 'nullable|string|max:255',
+                'appriseUrls' => 'nullable|string|max:10000',
+                'appriseCooldownMinutes' => 'required|integer|min:0|max:1440',
             ]);
-        } catch (\Illuminate\Validation\ValidationException $e) {
+        } catch (ValidationException $e) {
             $this->tab = self::tabForField((string) array_key_first($e->errors())) ?? $this->tab;
 
             throw $e;
@@ -325,6 +387,34 @@ class SettingsPage extends Component
         Setting::put('smtp_from_address', trim($this->smtpFromAddress));
         Setting::put('smtp_from_name', trim($this->smtpFromName));
         Setting::put('email_trusted_device_days', (string) $this->emailTrustedDeviceDays);
+
+        Setting::put('apprise_enabled', $this->appriseEnabled ? '1' : '0');
+        Setting::put('apprise_delivery_mode', $this->appriseMode);
+        Setting::put('apprise_cooldown_minutes', (string) $this->appriseCooldownMinutes);
+        foreach (AppriseNotifications::EVENTS as $event => $_label) {
+            $suffix = str_replace('.', '_', $event);
+            Setting::put('apprise_event_'.$suffix, ! empty($this->appriseEvents[$suffix]) ? '1' : '0');
+            $scope = ($this->appriseScopes[$suffix] ?? 'all') === 'selected' ? 'selected' : 'all';
+            Setting::put('apprise_scope_'.$suffix, $scope);
+            Setting::put('apprise_scope_groups_'.$suffix, json_encode(array_values(array_unique(array_map('intval', $this->appriseScopeGroups[$suffix] ?? [])))));
+            Setting::put('apprise_scope_devices_'.$suffix, json_encode(array_values(array_unique(array_map('intval', $this->appriseScopeDevices[$suffix] ?? [])))));
+        }
+        if ($this->appriseEndpoint !== '') {
+            Setting::put('apprise_endpoint', Crypt::encryptString(trim($this->appriseEndpoint)));
+            $this->appriseEndpoint = '';
+            $this->appriseEndpointSet = true;
+        }
+        if ($this->appriseConfigKey !== '') {
+            Setting::put('apprise_config_key', Crypt::encryptString(trim($this->appriseConfigKey)));
+            $this->appriseConfigKey = '';
+            $this->appriseConfigKeySet = true;
+        }
+        if ($this->appriseUrls !== '') {
+            $urls = preg_split('/[\r\n]+/', trim($this->appriseUrls)) ?: [];
+            Setting::put('apprise_urls', Crypt::encryptString(json_encode(array_values(array_filter(array_map('trim', $urls))))));
+            $this->appriseUrls = '';
+            $this->appriseUrlsSet = true;
+        }
 
         // Blank means "leave the stored password alone" — same rule as the SSO
         // client secret above.
@@ -416,6 +506,17 @@ class SettingsPage extends Component
         ConsoleAudit::record('settings.mail-test', 'Sent a test email to '.$to, 'settings', null);
     }
 
+    public function sendTestNotification(): void
+    {
+        $this->authorizeConsole('setting', 'rw');
+        $delivery = app(AppriseNotifications::class)->test();
+        $this->appriseTestOk = $delivery->status === NotificationDelivery::STATUS_SENT;
+        $this->appriseTestMessage = $this->appriseTestOk
+            ? 'Test notification sent.'
+            : ($delivery->error ?: 'Notification delivery failed.');
+        ConsoleAudit::record('settings.notification-test', 'Sent an Apprise test notification', 'settings', null);
+    }
+
     public function render()
     {
         return view('livewire.settings-page', [
@@ -424,6 +525,10 @@ class SettingsPage extends Component
             'oidcCallbackUrl' => route('login.oidc.callback'),
             'mailEnabled' => app(MailSettings::class)->isEnabled(),
             'usersWithoutEmail' => LoginEmailVerification::usersWithoutEmail(),
+            'appriseEventLabels' => AppriseNotifications::EVENTS,
+            'appriseDeviceGroups' => DeviceGroup::query()->orderBy('name')->get(['id', 'name']),
+            'appriseDevices' => Device::query()->approved()->orderByRaw("COALESCE(NULLIF(alias, ''), NULLIF(hostname, ''), rustdesk_id)")->get(['id', 'rustdesk_id', 'alias', 'hostname']),
+            'notificationDeliveries' => NotificationDelivery::query()->latest()->limit(10)->get(),
         ]);
     }
 }

--- a/app/Models/NotificationDelivery.php
+++ b/app/Models/NotificationDelivery.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Audit trail for outbound Apprise attempts. Transport configuration is held
+ * separately in encrypted settings and is deliberately absent from this table.
+ */
+#[Fillable(['event', 'subject', 'status', 'title', 'error'])]
+class NotificationDelivery extends Model
+{
+    public const STATUS_SENT = 'sent';
+
+    public const STATUS_FAILED = 'failed';
+
+    public const STATUS_SUPPRESSED = 'suppressed';
+}

--- a/app/Services/AppriseNotifications.php
+++ b/app/Services/AppriseNotifications.php
@@ -1,0 +1,274 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Device;
+use App\Models\NotificationDelivery;
+use App\Models\Setting;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Crypt;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+/**
+ * Small synchronous Apprise API client. It uses Laravel's HTTP client rather
+ * than spawning a binary, keeping URLs and credentials out of process args.
+ */
+class AppriseNotifications
+{
+    public const MODE_CONFIG = 'config';
+
+    public const MODE_URLS = 'urls';
+
+    public const EVENTS = [
+        'device.pending_approval' => 'Device pending approval',
+        'device.offline' => 'Device offline',
+        'device.online' => 'Device recovered',
+        'console.login_failed' => 'Failed console login',
+        'security.alarm' => 'Security alarm',
+        'remote_connection.failure' => 'Repeated remote connection failure',
+    ];
+
+    /**
+     * Send an enabled event. The subject scopes its cooldown (a silent device
+     * must not suppress a different device's security event).
+     */
+    public function send(string $event, string $title, string $body, ?string $subject = null, ?Device $device = null): ?NotificationDelivery
+    {
+        if (! $this->isEnabledFor($event) || ! $this->allowsDevice($event, $device)) {
+            return null;
+        }
+
+        $cooldown = $this->cooldownSeconds();
+        $key = 'apprise:cooldown:'.sha1($event.'|'.($subject ?? 'global'));
+
+        if ($cooldown > 0 && ! Cache::add($key, true, $cooldown)) {
+            // A minute-by-minute presence sweep would otherwise create a log
+            // row for every suppressed tick. Delivery history records actual
+            // attempts; the cache enforces quiet periods without audit noise.
+            return null;
+        }
+
+        return $this->deliver($event, $title, $body, $subject);
+    }
+
+    /** Send a saved-config test regardless of the event switches. */
+    public function test(): NotificationDelivery
+    {
+        return $this->deliver(
+            'test',
+            'CortenDesk notification test',
+            'This is a test notification from '.config('app.name').'.',
+            'settings-test',
+        );
+    }
+
+    public function isConfigured(): bool
+    {
+        $endpoint = $this->secret('apprise_endpoint');
+        if (! $this->validEndpoint($endpoint)) {
+            return false;
+        }
+
+        return $this->mode() === self::MODE_CONFIG
+            ? trim($this->secret('apprise_config_key')) !== ''
+            : $this->urls() !== [];
+    }
+
+    public function isEnabledFor(string $event): bool
+    {
+        return Setting::get('apprise_enabled', '0') === '1'
+            && array_key_exists($event, self::EVENTS)
+            && Setting::get('apprise_event_'.$this->settingSuffix($event), '0') === '1'
+            && $this->isConfigured();
+    }
+
+    /**
+     * Redact transport credentials from delivery failures and UI/audit strings.
+     * The method is public so callers adding user-visible diagnostics can use
+     * the same single safe transformation.
+     */
+    public static function redact(string $value): string
+    {
+        // Keep transport details out of persistent logs. Apprise destinations use
+        // many non-HTTP schemes and commonly place tokens in their path, so the
+        // whole URI is removed rather than trying to preserve a "safe" prefix.
+        $value = preg_replace(
+            '~\b[a-z][a-z0-9+.-]*://[^\s"\']+~i',
+            '[redacted URL]',
+            $value,
+        ) ?? '[redacted error]';
+
+        return preg_replace(
+            '/\b(token|secret|password|authorization|api[_-]?key|access[_-]?token)\s*[=:]\s*[^\s,;]+/i',
+            '$1=[redacted]',
+            $value,
+        ) ?? '[redacted error]';
+    }
+
+    private function deliver(string $event, string $title, string $body, ?string $subject): NotificationDelivery
+    {
+        if (! $this->isConfigured()) {
+            return $this->record($event, $title, $subject, NotificationDelivery::STATUS_FAILED, 'Apprise is not configured.');
+        }
+
+        // Best-effort delivery with tight transport deadlines. Notification
+        // failures are contained and never change API or authentication
+        // responses, but enabled events can add up to three seconds while an
+        // unreachable self-hosted Apprise endpoint times out.
+        try {
+            $response = Http::acceptJson()
+                ->asJson()
+                ->timeout(3)
+                ->connectTimeout(1)
+                ->post($this->notifyUrl(), $this->payload($title, $body));
+
+            if ($response->successful()) {
+                return $this->record($event, $title, $subject, NotificationDelivery::STATUS_SENT);
+            }
+
+            return $this->record(
+                $event,
+                $title,
+                $subject,
+                NotificationDelivery::STATUS_FAILED,
+                'Apprise returned HTTP '.$response->status().'. '.self::redact((string) $response->body()),
+            );
+        } catch (ConnectionException $e) {
+            Log::warning('Apprise notification delivery failed.', ['event' => $event, 'error' => self::redact($e->getMessage())]);
+
+            return $this->record($event, $title, $subject, NotificationDelivery::STATUS_FAILED, self::redact($e->getMessage()));
+        } catch (Throwable $e) {
+            // Notifications must never break auth, presence, or audit APIs.
+            Log::warning('Apprise notification delivery failed.', ['event' => $event, 'error' => self::redact($e->getMessage())]);
+
+            return $this->record($event, $title, $subject, NotificationDelivery::STATUS_FAILED, self::redact($e->getMessage()));
+        }
+    }
+
+    /** @return array<string, mixed> */
+    private function payload(string $title, string $body): array
+    {
+        $payload = [
+            'title' => $title,
+            'body' => $body,
+            'type' => 'warning',
+        ];
+
+        if ($this->mode() === self::MODE_URLS) {
+            $payload['urls'] = $this->urls();
+        }
+
+        return $payload;
+    }
+
+    private function notifyUrl(): string
+    {
+        $endpoint = $this->secret('apprise_endpoint');
+        $parts = parse_url($endpoint);
+
+        // isConfigured() verified this already. Preserve an endpoint query
+        // (some self-hosted Apprise APIs protect their API route that way) but
+        // put it AFTER the /notify path, never inside the config key path.
+        $base = ($parts['scheme'] ?? 'https').'://';
+        if (isset($parts['user']) || isset($parts['pass'])) {
+            $base .= rawurlencode((string) ($parts['user'] ?? ''));
+            if (isset($parts['pass'])) {
+                $base .= ':'.rawurlencode((string) $parts['pass']);
+            }
+            $base .= '@';
+        }
+        $base .= $parts['host'] ?? '';
+        if (isset($parts['port'])) {
+            $base .= ':'.$parts['port'];
+        }
+
+        $path = rtrim((string) ($parts['path'] ?? ''), '/').'/notify';
+        if ($this->mode() === self::MODE_CONFIG) {
+            $path .= '/'.rawurlencode($this->secret('apprise_config_key'));
+        }
+
+        return $base.$path.(isset($parts['query']) ? '?'.$parts['query'] : '');
+    }
+
+    private function mode(): string
+    {
+        return Setting::get('apprise_delivery_mode', self::MODE_CONFIG) === self::MODE_URLS
+            ? self::MODE_URLS
+            : self::MODE_CONFIG;
+    }
+
+    /** @return list<string> */
+    private function urls(): array
+    {
+        $decoded = json_decode($this->secret('apprise_urls'), true);
+
+        return is_array($decoded)
+            ? array_values(array_filter(array_map('trim', $decoded), fn ($url) => is_string($url) && $url !== ''))
+            : [];
+    }
+
+    private function secret(string $key): string
+    {
+        $value = Setting::get($key, '') ?? '';
+        if ($value === '') {
+            return '';
+        }
+
+        try {
+            return Crypt::decryptString($value);
+        } catch (Throwable) {
+            // Existing plaintext values are ignored rather than accidentally
+            // copied into a URL/error path. Operators can re-save securely.
+            return '';
+        }
+    }
+
+    private function cooldownSeconds(): int
+    {
+        return max(0, min(1440, (int) Setting::get('apprise_cooldown_minutes', '15'))) * 60;
+    }
+
+    private function settingSuffix(string $event): string
+    {
+        return str_replace(['.', '-'], '_', $event);
+    }
+
+    private function allowsDevice(string $event, ?Device $device): bool
+    {
+        $suffix = $this->settingSuffix($event);
+        if ($device === null || Setting::get('apprise_scope_'.$suffix, 'all') !== 'selected') {
+            return true;
+        }
+
+        $groupIds = json_decode((string) Setting::get('apprise_scope_groups_'.$suffix, '[]'), true);
+        $deviceIds = json_decode((string) Setting::get('apprise_scope_devices_'.$suffix, '[]'), true);
+        $groups = array_map('intval', is_array($groupIds) ? $groupIds : []);
+        $devices = array_map('intval', is_array($deviceIds) ? $deviceIds : []);
+
+        return in_array((int) $device->id, $devices, true)
+            || ($device->device_group_id !== null && in_array((int) $device->device_group_id, $groups, true));
+    }
+
+    private function validEndpoint(string $endpoint): bool
+    {
+        $parts = parse_url($endpoint);
+
+        return is_array($parts)
+            && isset($parts['host'])
+            && in_array(strtolower((string) ($parts['scheme'] ?? '')), ['http', 'https'], true);
+    }
+
+    private function record(string $event, string $title, ?string $subject, string $status, ?string $error = null): NotificationDelivery
+    {
+        return NotificationDelivery::create([
+            'event' => $event,
+            'subject' => $subject,
+            'status' => $status,
+            'title' => self::redact($title),
+            'error' => $error === null ? null : mb_substr(self::redact($error), 0, 2_000),
+        ]);
+    }
+}

--- a/app/Services/AppriseNotifications.php
+++ b/app/Services/AppriseNotifications.php
@@ -101,6 +101,15 @@ class AppriseNotifications
             $value,
         ) ?? '[redacted error]';
 
+        // Error responses are often JSON. Redact quoted sensitive keys before
+        // the generic key=value pass so echoed credentials never reach the
+        // delivery table, logs, or Settings UI.
+        $value = preg_replace(
+            '/("(?:token|secret|password|authorization|api[_-]?key|access[_-]?token)"\s*:\s*)"(?:\\\\.|[^"\\\\])*"/i',
+            '$1"[redacted]"',
+            $value,
+        ) ?? '[redacted error]';
+
         return preg_replace(
             '/\b(token|secret|password|authorization|api[_-]?key|access[_-]?token)\s*[=:]\s*[^\s,;]+/i',
             '$1=[redacted]',

--- a/database/migrations/2026_08_12_000001_create_notification_deliveries_table.php
+++ b/database/migrations/2026_08_12_000001_create_notification_deliveries_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('notification_deliveries', function (Blueprint $table) {
+            $table->id();
+            $table->string('event', 64)->index();
+            // A device id, alarm id, or login source used for cooldown/audit.
+            // Never a destination URL or other transport credential.
+            $table->string('subject', 255)->nullable()->index();
+            $table->string('status', 16)->index(); // sent | failed | suppressed
+            $table->string('title', 255);
+            $table->text('error')->nullable(); // sanitized: transport URLs/tokens are redacted
+            $table->timestamps();
+
+            $table->index(['event', 'created_at']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('notification_deliveries');
+    }
+};

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true">
+    <testsuites>
+        <testsuite name="Feature">
+            <directory suffix="Test.php">tests/Feature</directory>
+        </testsuite>
+    </testsuites>
+    <source>
+        <include>
+            <directory suffix=".php">app</directory>
+        </include>
+    </source>
+    <php>
+        <env name="APP_ENV" value="testing"/>
+        <env name="APP_KEY" value="base64:Zz+no3PHeceejB5smZOtKwCFj1N+zMiYdlkoOhi7EJE="/>
+        <env name="BCRYPT_ROUNDS" value="4"/>
+        <env name="CACHE_STORE" value="array"/>
+        <env name="DB_CONNECTION" value="sqlite"/>
+        <env name="DB_DATABASE" value=":memory:"/>
+        <env name="MAIL_MAILER" value="array"/>
+        <env name="QUEUE_CONNECTION" value="sync"/>
+        <env name="SESSION_DRIVER" value="array"/>
+    </php>
+</phpunit>

--- a/resources/views/livewire/settings-page.blade.php
+++ b/resources/views/livewire/settings-page.blade.php
@@ -48,6 +48,7 @@
             'security'    => ['ri-shield-keyhole-line', 'Security'],
             'sso'         => ['ri-shield-user-line', 'SSO'],
             'email'       => ['ri-mail-send-line', 'Email'],
+            'notifications' => ['ri-notification-3-line', 'Notifications'],
             'maintenance' => ['ri-database-2-line', 'Maintenance'],
         ];
     @endphp
@@ -589,6 +590,87 @@
                                     {{ $smtpTestMessage }}
                                 </div>
                             @endif
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        {{-- ======================== NOTIFICATIONS ======================== --}}
+        <div class="tab-pane {{ $tab === 'notifications' ? 'show active' : '' }}">
+            <div class="row">
+                <div class="col-lg-8">
+                    <div class="card">
+                        <div class="card-header"><h5 class="card-title mb-0">Apprise notifications</h5></div>
+                        <div class="card-body">
+                            <p class="text-muted fs-13">Send fleet and security events through a self-hosted Apprise API. Destination credentials are encrypted and never shown again.</p>
+                            <form wire:submit="save">
+                                <div class="form-check form-switch mb-3">
+                                    <input class="form-check-input" type="checkbox" id="appriseEnabled" wire:model="appriseEnabled">
+                                    <label class="form-check-label" for="appriseEnabled">Enable notifications</label>
+                                </div>
+                                <div class="mb-3">
+                                    <label class="form-label">Apprise API endpoint</label>
+                                    <input type="url" class="form-control @error('appriseEndpoint') is-invalid @enderror" wire:model="appriseEndpoint"
+                                           placeholder="{{ $appriseEndpointSet ? 'Stored — leave blank to keep' : 'https://apprise.example.com' }}">
+                                    @error('appriseEndpoint')<div class="invalid-feedback">{{ $message }}</div>@enderror
+                                    <div class="form-text">Base URL only. CortenDesk appends <code>/notify</code>.</div>
+                                </div>
+                                <div class="mb-3">
+                                    <label class="form-label">Delivery mode</label>
+                                    <select class="form-select" wire:model.live="appriseMode">
+                                        <option value="config">Saved Apprise configuration key</option>
+                                        <option value="urls">Stateless Apprise URLs</option>
+                                    </select>
+                                </div>
+                                @if ($appriseMode === 'config')
+                                    <div class="mb-3"><label class="form-label">Configuration key</label><input type="password" class="form-control" wire:model="appriseConfigKey" placeholder="{{ $appriseConfigKeySet ? 'Stored — leave blank to keep' : 'office-alerts' }}"></div>
+                                @else
+                                    <div class="mb-3"><label class="form-label">Apprise URLs</label><textarea class="form-control rd-mono" rows="4" wire:model="appriseUrls" placeholder="{{ $appriseUrlsSet ? 'Stored — leave blank to keep' : 'One Apprise URL per line' }}"></textarea><div class="form-text">Write-only and encrypted at rest.</div></div>
+                                @endif
+                                <div class="mb-3"><label class="form-label">Cooldown (minutes)</label><input type="number" class="form-control" style="max-width: 140px" min="0" max="1440" wire:model="appriseCooldownMinutes"></div>
+                                <div class="row">
+                                    @foreach ($appriseEventLabels as $event => $label)
+                                        @php $eventKey = str_replace('.', '_', $event); @endphp
+                                        <div class="col-md-6 mb-3">
+                                            <div class="form-check form-switch">
+                                                <input class="form-check-input" type="checkbox" id="event-{{ str_replace('.', '-', $event) }}" wire:model="appriseEvents.{{ $eventKey }}">
+                                                <label class="form-check-label" for="event-{{ str_replace('.', '-', $event) }}">{{ $label }}</label>
+                                            </div>
+                                            @if (str_starts_with($event, 'device.'))
+                                                <select class="form-select form-select-sm mt-2" wire:model.live="appriseScopes.{{ $eventKey }}">
+                                                    <option value="all">All approved devices</option>
+                                                    <option value="selected">Selected groups or devices</option>
+                                                </select>
+                                                @if (($appriseScopes[$eventKey] ?? 'all') === 'selected')
+                                                    <select class="form-select form-select-sm mt-2" multiple wire:model="appriseScopeGroups.{{ $eventKey }}" aria-label="Groups for {{ $label }}">
+                                                        @foreach ($appriseDeviceGroups as $group)<option value="{{ $group->id }}">Group: {{ $group->name }}</option>@endforeach
+                                                    </select>
+                                                    <select class="form-select form-select-sm mt-2" multiple wire:model="appriseScopeDevices.{{ $eventKey }}" aria-label="Devices for {{ $label }}">
+                                                        @foreach ($appriseDevices as $device)<option value="{{ $device->id }}">{{ $device->alias ?: ($device->hostname ?: $device->rustdesk_id) }}</option>@endforeach
+                                                    </select>
+                                                @endif
+                                            @endif
+                                        </div>
+                                    @endforeach
+                                </div>
+                                <button class="btn btn-primary mt-2" type="submit" @disabled(! $canManageSettings)><i class="ri-save-line me-1"></i>Save settings</button>
+                                <button class="btn btn-outline-secondary mt-2" type="button" wire:click="sendTestNotification" @disabled(! $canManageSettings)>Send test</button>
+                                @if ($appriseTestMessage)<div class="alert {{ $appriseTestOk ? 'alert-success' : 'alert-danger' }} py-2 mt-3 mb-0">{{ $appriseTestMessage }}</div>@endif
+                            </form>
+                        </div>
+                    </div>
+                    <div class="card">
+                        <div class="card-header"><h5 class="card-title mb-0">Recent deliveries</h5></div>
+                        <div class="card-body">
+                            @forelse ($notificationDeliveries as $delivery)
+                                <div class="d-flex justify-content-between gap-3 border-bottom py-2">
+                                    <div><strong>{{ $delivery->title }}</strong><div class="text-muted fs-13">{{ $delivery->event }} · {{ $delivery->created_at?->diffForHumans() }}</div>@if($delivery->error)<div class="text-danger fs-13 text-break">{{ $delivery->error }}</div>@endif</div>
+                                    <span class="badge {{ $delivery->status === 'sent' ? 'bg-success-subtle text-success' : 'bg-danger-subtle text-danger' }}">{{ $delivery->status }}</span>
+                                </div>
+                            @empty
+                                <p class="text-muted mb-0">No delivery attempts yet.</p>
+                            @endforelse
                         </div>
                     </div>
                 </div>

--- a/routes/console.php
+++ b/routes/console.php
@@ -18,3 +18,6 @@ Schedule::command('cortendesk:prune-invitations')->dailyAt('04:20');
 // Sessions on devices that have gone silent (issue #10). Frequent, not nightly:
 // this drives what the dashboard reports as happening right now.
 Schedule::command('cortendesk:close-stale-sessions')->everyFiveMinutes()->withoutOverlapping();
+
+// Presence transitions for configurable Apprise notifications.
+Schedule::command('cortendesk:check-device-notifications')->everyMinute()->withoutOverlapping();

--- a/tests/CreatesApplication.php
+++ b/tests/CreatesApplication.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tests;
+
+use Illuminate\Contracts\Console\Kernel;
+use Illuminate\Foundation\Application;
+
+trait CreatesApplication
+{
+    public function createApplication(): Application
+    {
+        $app = require __DIR__.'/../bootstrap/app.php';
+
+        $app->make(Kernel::class)->bootstrap();
+
+        return $app;
+    }
+}

--- a/tests/Feature/AppriseNotificationsTest.php
+++ b/tests/Feature/AppriseNotificationsTest.php
@@ -185,6 +185,23 @@ class AppriseNotificationsTest extends TestCase
             && ! str_contains((string) $context['error'], 'private.example.test'));
     }
 
+    public function test_json_error_bodies_cannot_leak_quoted_secrets(): void
+    {
+        $this->configureApprise(['security_alarm']);
+        Http::fake(['*' => Http::response([
+            'access_token' => 'top-secret',
+            'password' => 'hunter2',
+            'message' => 'delivery rejected',
+        ], 400)]);
+
+        $delivery = app(AppriseNotifications::class)->send('security.alarm', 'Alarm', 'Body', 'alarm:6');
+
+        $this->assertSame('failed', $delivery?->status);
+        $this->assertStringNotContainsString('top-secret', (string) $delivery?->error);
+        $this->assertStringNotContainsString('hunter2', (string) $delivery?->error);
+        $this->assertStringContainsString('[redacted]', (string) $delivery?->error);
+    }
+
     public function test_presence_command_detects_offline_and_recovery_once_each(): void
     {
         $this->configureApprise(['device_offline', 'device_online']);

--- a/tests/Feature/AppriseNotificationsTest.php
+++ b/tests/Feature/AppriseNotificationsTest.php
@@ -1,0 +1,234 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Console\Commands\CheckDeviceNotifications;
+use App\Livewire\SettingsPage;
+use App\Models\Device;
+use App\Models\DeviceGroup;
+use App\Models\NotificationDelivery;
+use App\Models\Setting;
+use App\Models\User;
+use App\Services\AppriseNotifications;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Crypt;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class AppriseNotificationsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_sends_a_configured_stateful_apprise_notification_and_records_a_safe_delivery_log(): void
+    {
+        $this->configureApprise(['security_alarm']);
+
+        Http::fake([
+            'https://api.example.test/apprise/notify/office-alerts?access_token=secret' => Http::response(['result' => 'success']),
+        ]);
+
+        $delivery = app(AppriseNotifications::class)->send(
+            'security.alarm',
+            'Security alarm',
+            'Device 123 reported an alarm.',
+            'alarm:123:1',
+        );
+
+        $this->assertNotNull($delivery);
+        $this->assertSame('sent', $delivery->status, $delivery->error ?? 'Delivery did not send.');
+        $this->assertDatabaseHas('notification_deliveries', [
+            'event' => 'security.alarm',
+            'subject' => 'alarm:123:1',
+            'status' => 'sent',
+        ]);
+        $this->assertStringNotContainsString('secret', (string) $delivery->error);
+        $this->assertDatabaseMissing('notification_deliveries', [
+            'error' => 'https://api.example.test/apprise?access_token=secret',
+        ]);
+
+        Http::assertSent(function ($request) {
+            return $request->url() === 'https://api.example.test/apprise/notify/office-alerts?access_token=secret'
+                && $request['title'] === 'Security alarm'
+                && $request['body'] === 'Device 123 reported an alarm.'
+                && $request['type'] === 'warning';
+        });
+    }
+
+    public function test_it_honors_cooldown_without_creating_delivery_log_noise(): void
+    {
+        $this->configureApprise(['device_offline']);
+        Http::fake(['*' => Http::response(['result' => 'success'])]);
+
+        $notifications = app(AppriseNotifications::class);
+        $this->assertSame('sent', $notifications->send('device.offline', 'Device offline', 'Host is offline.', 'device:1')?->status);
+        $this->assertNull($notifications->send('device.offline', 'Device offline', 'Host is offline.', 'device:1'));
+
+        Http::assertSentCount(1);
+        $this->assertSame(1, NotificationDelivery::query()->count());
+    }
+
+    public function test_device_events_can_be_scoped_to_selected_groups_or_devices(): void
+    {
+        $this->configureApprise(['device_offline']);
+        Http::fake(['*' => Http::response(['result' => 'success'])]);
+        $group = DeviceGroup::create(['name' => 'Servers']);
+        $includedByGroup = Device::create(['rustdesk_id' => '101', 'uuid' => 'grouped', 'status' => Device::STATUS_ACTIVE, 'device_group_id' => $group->id]);
+        $includedDirectly = Device::create(['rustdesk_id' => '102', 'uuid' => 'direct', 'status' => Device::STATUS_ACTIVE]);
+        $excluded = Device::create(['rustdesk_id' => '103', 'uuid' => 'excluded', 'status' => Device::STATUS_ACTIVE]);
+
+        Setting::put('apprise_scope_device_offline', 'selected');
+        Setting::put('apprise_scope_groups_device_offline', json_encode([$group->id]));
+        Setting::put('apprise_scope_devices_device_offline', json_encode([$includedDirectly->id]));
+
+        $notifications = app(AppriseNotifications::class);
+        $this->assertSame('sent', $notifications->send('device.offline', 'Offline', 'Grouped', 'device:101', $includedByGroup)?->status);
+        $this->assertSame('sent', $notifications->send('device.offline', 'Offline', 'Direct', 'device:102', $includedDirectly)?->status);
+        $this->assertNull($notifications->send('device.offline', 'Offline', 'Excluded', 'device:103', $excluded));
+        Http::assertSentCount(2);
+    }
+
+    public function test_it_uses_stateless_urls_without_exposing_them_in_the_delivery_log(): void
+    {
+        $this->configureApprise(['security_alarm'], 'urls');
+        Setting::put('apprise_urls', Crypt::encryptString(json_encode([
+            'jsons://hooks.example.test/secret-token',
+        ])));
+        Http::fake(['https://api.example.test/apprise/notify?access_token=secret' => Http::response(['result' => 'success'])]);
+
+        $delivery = app(AppriseNotifications::class)->send('security.alarm', 'Security alarm', 'Body', 'alarm:4');
+
+        $this->assertSame('sent', $delivery?->status);
+        Http::assertSent(fn ($request) => $request['urls'] === ['jsons://hooks.example.test/secret-token']);
+        $this->assertStringNotContainsString('secret-token', (string) $delivery?->error);
+        $this->assertStringNotContainsString('hooks.example.test', (string) $delivery?->error);
+        $this->assertSame('Delivery to [redacted URL] failed', AppriseNotifications::redact('Delivery to jsons://hooks.example.test/secret-token failed'));
+    }
+
+    public function test_settings_save_encrypts_write_only_apprise_transport_fields(): void
+    {
+        $admin = User::factory()->admin()->create();
+
+        Livewire::actingAs($admin)->test(SettingsPage::class)
+            ->set('appriseEndpoint', 'https://apprise.example.test?access_token=secret')
+            ->set('appriseConfigKey', 'office-alerts')
+            ->set('appriseEnabled', true)
+            ->set('appriseEvents.security_alarm', true)
+            ->set('appriseScopes.device_offline', 'selected')
+            ->set('appriseScopeGroups.device_offline', [12])
+            ->set('appriseScopeDevices.device_offline', [34])
+            ->call('save')
+            ->assertHasNoErrors()
+            ->assertSet('appriseEndpoint', '')
+            ->assertSet('appriseConfigKey', '');
+
+        $storedEndpoint = (string) Setting::get('apprise_endpoint', '');
+        $this->assertStringNotContainsString('apprise.example.test', $storedEndpoint);
+        $this->assertSame('https://apprise.example.test?access_token=secret', Crypt::decryptString($storedEndpoint));
+        $this->assertSame('office-alerts', Crypt::decryptString((string) Setting::get('apprise_config_key', '')));
+        $this->assertSame('1', Setting::get('apprise_event_security_alarm'));
+        $this->assertSame('selected', Setting::get('apprise_scope_device_offline'));
+        $this->assertSame([12], json_decode((string) Setting::get('apprise_scope_groups_device_offline'), true));
+        $this->assertSame([34], json_decode((string) Setting::get('apprise_scope_devices_device_offline'), true));
+    }
+
+    public function test_reliable_api_and_console_paths_emit_their_enabled_events(): void
+    {
+        $this->configureApprise([
+            'device_pending_approval',
+            'console_login_failed',
+            'security_alarm',
+            'remote_connection_failure',
+        ]);
+        Setting::put('require_device_approval', '1');
+        Http::fake(['*' => Http::response(['result' => 'success'])]);
+
+        $this->postJson('/api/sysinfo', [
+            'id' => '123456789',
+            'uuid' => 'new-device',
+            'hostname' => 'Awaiting approval',
+        ])->assertOk();
+
+        $this->post('/login', ['username' => 'nobody', 'password' => 'wrong'])
+            ->assertSessionHasErrors('username');
+
+        $this->postJson('/api/audit/alarm', [
+            'id' => '123456789',
+            'uuid' => 'new-device',
+            'typ' => 1,
+            'info' => '{"detail":"many failures"}',
+        ])->assertOk();
+
+        $sentBodies = collect(Http::recorded())->map(fn ($pair) => (string) $pair[0]['body'])->all();
+        $this->assertFalse(collect($sentBodies)->contains(fn ($body) => str_contains($body, 'nobody') || str_contains($body, 'wrong')));
+        $this->assertDatabaseHas('notification_deliveries', ['event' => 'device.pending_approval', 'status' => 'sent']);
+        $this->assertDatabaseHas('notification_deliveries', ['event' => 'console.login_failed', 'status' => 'sent']);
+        $this->assertDatabaseHas('notification_deliveries', ['event' => 'security.alarm', 'status' => 'sent']);
+        $this->assertDatabaseHas('notification_deliveries', ['event' => 'remote_connection.failure', 'status' => 'sent']);
+    }
+
+    public function test_delivery_exceptions_are_redacted_and_never_escape(): void
+    {
+        $this->configureApprise(['security_alarm']);
+        Log::spy();
+        Http::fake(fn () => throw new \RuntimeException('token=top-secret https://private.example.test/hook'));
+
+        $delivery = app(AppriseNotifications::class)->send('security.alarm', 'Alarm', 'Body', 'alarm:5');
+
+        $this->assertSame('failed', $delivery?->status);
+        $this->assertStringNotContainsString('top-secret', (string) $delivery?->error);
+        $this->assertStringNotContainsString('private.example.test', (string) $delivery?->error);
+        Log::shouldHaveReceived('warning')->once()->withArgs(fn ($message, $context) => $message === 'Apprise notification delivery failed.'
+            && ! str_contains((string) $context['error'], 'top-secret')
+            && ! str_contains((string) $context['error'], 'private.example.test'));
+    }
+
+    public function test_presence_command_detects_offline_and_recovery_once_each(): void
+    {
+        $this->configureApprise(['device_offline', 'device_online']);
+        Setting::put('online_window', '60');
+        Http::fake(['*' => Http::response(['result' => 'success'])]);
+
+        $device = Device::create([
+            'rustdesk_id' => '123456789',
+            'uuid' => 'device-one',
+            'hostname' => 'Workstation',
+            'status' => Device::STATUS_ACTIVE,
+            'last_online_at' => now()->subMinutes(2),
+        ]);
+
+        $this->artisan(CheckDeviceNotifications::class)->assertExitCode(0);
+        $this->assertDatabaseHas('notification_deliveries', [
+            'event' => 'device.offline',
+            'subject' => 'device:'.$device->rustdesk_id,
+            'status' => 'sent',
+        ]);
+
+        $device->update(['last_online_at' => now()]);
+        $this->artisan(CheckDeviceNotifications::class)->assertExitCode(0);
+        $this->assertDatabaseHas('notification_deliveries', [
+            'event' => 'device.online',
+            'subject' => 'device:'.$device->rustdesk_id,
+            'status' => 'sent',
+        ]);
+
+        $this->assertSame(2, NotificationDelivery::query()->count());
+    }
+
+    /** @param list<string> $events */
+    private function configureApprise(array $events, string $mode = 'config'): void
+    {
+        Cache::clear();
+        Setting::put('apprise_enabled', '1');
+        Setting::put('apprise_endpoint', Crypt::encryptString('https://api.example.test/apprise?access_token=secret'));
+        Setting::put('apprise_delivery_mode', $mode);
+        Setting::put('apprise_config_key', Crypt::encryptString('office-alerts'));
+        Setting::put('apprise_cooldown_minutes', '15');
+
+        foreach (AppriseNotifications::EVENTS as $event => $_) {
+            Setting::put('apprise_event_'.str_replace('.', '_', $event), in_array(str_replace('.', '_', $event), $events, true) ? '1' : '0');
+        }
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Tests;
+
+use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
+
+abstract class TestCase extends BaseTestCase
+{
+    use CreatesApplication;
+}


### PR DESCRIPTION
## Summary

- Adds configurable system, security, and fleet notifications through a self-hosted Apprise API.
- Supports encrypted write-only endpoint/configuration values, stateful keys, and stateless Apprise URLs.
- Adds per-event switches, cooldowns, and optional device/group scopes.
- Covers pending approvals, offline/recovered devices, failed console/client sign-ins, security alarms, and repeated connection failures.
- Records sanitized delivery history and includes it in existing retention pruning.

## Safety and reliability

- Transport URLs and credentials are encrypted at rest and never displayed after saving.
- Delivery records and warning logs redact URLs, tokens, and credential-shaped values.
- Notification failures never alter authentication, audit, or RustDesk API responses.
- Requests use bounded timeouts and no credentials are passed through process arguments.
- Failed-login message bodies do not include attempted usernames, passwords, or source IPs.

## Testing

- `php artisan test --compact` — 9 tests, 51 assertions passed
- `php artisan view:cache`
- Pint checks for all changed PHP files
- `git diff --check origin/main...HEAD`

## Scope

This extends the system-alert portion of #22. It does not replace transactional email used for invitations, verification, or password recovery.
