### PR TITLE
feat: add first-run setup wizard

### DIFF
--- a/app/Livewire/SetupWizard.php
+++ b/app/Livewire/SetupWizard.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Livewire;
+
+use App\Livewire\Concerns\AuthorizesConsole;
+use App\Models\ConsoleAudit;
+use App\Models\Device;
+use App\Models\Setting;
+use App\Models\User;
+use Livewire\Component;
+
+class SetupWizard extends Component
+{
+    use AuthorizesConsole;
+
+    public bool $deviceConnected = false;
+
+    public function mount(): void
+    {
+        $this->authorizeConsole('setting', 'r');
+        $this->deviceConnected = Device::query()->whereNotNull('last_online_at')->exists();
+    }
+
+    public static function shouldPrompt(?User $user): bool
+    {
+        return $user !== null
+            && $user->consoleAllows('setting', 'rw')
+            && $user->setup_wizard_dismissed_at === null
+            && $user->setup_wizard_completed_at === null
+            && ! Device::query()->exists();
+    }
+
+    public function refreshDeviceStatus(): void
+    {
+        $this->deviceConnected = Device::query()->whereNotNull('last_online_at')->exists();
+    }
+
+    public function dismiss(): void
+    {
+        $this->authorizeConsole('setting', 'rw');
+        auth()->user()->forceFill(['setup_wizard_dismissed_at' => now()])->save();
+        ConsoleAudit::record('setup.dismiss', 'Dismissed the first-run setup guide', 'settings', null);
+
+        $this->redirectRoute('overview');
+    }
+
+    public function complete(): void
+    {
+        $this->authorizeConsole('setting', 'rw');
+        $this->refreshDeviceStatus();
+
+        if (! $this->deviceConnected) {
+            $this->addError('device', 'Connect a RustDesk device before completing setup.');
+
+            return;
+        }
+
+        auth()->user()->forceFill(['setup_wizard_completed_at' => now()])->save();
+        ConsoleAudit::record('setup.complete', 'Completed the first-run setup guide', 'settings', null);
+
+        $this->redirectRoute('devices');
+    }
+
+    public function render()
+    {
+        return view('livewire.setup-wizard', [
+            'idServer' => Setting::get('id_server', config('cortendesk.id_server')) ?? '',
+            'relayServer' => Setting::get('relay_server', config('cortendesk.relay_server')) ?? '',
+            'publicKey' => Setting::get('public_key', config('cortendesk.public_key')) ?? '',
+            'apiUrl' => rtrim((string) config('app.url'), '/'),
+            'approvalEnabled' => Setting::get('require_device_approval', '0') === '1',
+            'twoFactorRequired' => Setting::get('two_factor_required', '0') === '1'
+                || Setting::get('two_factor_required_admins', '0') === '1',
+        ]);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -2,7 +2,6 @@
 
 namespace App\Models;
 
-use App\Models\AddressBook;
 use App\Support\Permissions;
 use Database\Factories\UserFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
@@ -17,7 +16,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 
-#[Fillable(['username', 'name', 'email', 'password', 'avatar', 'is_admin', 'role_id', 'is_active', 'note', 'devices_columns'])]
+#[Fillable(['username', 'name', 'email', 'password', 'avatar', 'is_admin', 'role_id', 'is_active', 'note', 'devices_columns', 'setup_wizard_dismissed_at', 'setup_wizard_completed_at'])]
 #[Hidden(['password', 'remember_token', 'totp_secret'])]
 class User extends Authenticatable
 {
@@ -47,6 +46,8 @@ class User extends Authenticatable
             'totp_confirmed_at' => 'datetime',
             // Devices-screen column selection (issue #16); null = defaults.
             'devices_columns' => 'array',
+            'setup_wizard_dismissed_at' => 'datetime',
+            'setup_wizard_completed_at' => 'datetime',
         ];
     }
 

--- a/database/migrations/2026_08_12_000020_add_setup_wizard_state_to_users.php
+++ b/database/migrations/2026_08_12_000020_add_setup_wizard_state_to_users.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->timestamp('setup_wizard_dismissed_at')->nullable()->after('devices_columns');
+            $table->timestamp('setup_wizard_completed_at')->nullable()->after('setup_wizard_dismissed_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn(['setup_wizard_dismissed_at', 'setup_wizard_completed_at']);
+        });
+    }
+};

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true">
+    <testsuites>
+        <testsuite name="Feature"><directory>tests/Feature</directory></testsuite>
+    </testsuites>
+    <php>
+        <env name="APP_ENV" value="testing"/>
+        <env name="APP_KEY" value="base64:RS1QLhuuYPHOBOwym/pch/YMJbc+FyZrwFNZHaogPqQ="/>
+        <env name="BCRYPT_ROUNDS" value="4"/>
+        <env name="CACHE_STORE" value="array"/>
+        <env name="DB_CONNECTION" value="sqlite"/>
+        <env name="DB_DATABASE" value=":memory:"/>
+        <env name="MAIL_MAILER" value="array"/>
+        <env name="QUEUE_CONNECTION" value="sync"/>
+        <env name="SESSION_DRIVER" value="array"/>
+    </php>
+</phpunit>

--- a/resources/views/livewire/device-list.blade.php
+++ b/resources/views/livewire/device-list.blade.php
@@ -287,6 +287,9 @@
                                 </p>
                                 @unless ($trashed)
                                     <button type="button" class="btn btn-sm btn-outline-light" wire:click="resetFilters">Clear filters</button>
+                                    @if (auth()->user()?->consoleAllows('setting', 'r'))
+                                        <a href="{{ route('setup') }}" class="btn btn-sm btn-primary">Set up a client</a>
+                                    @endif
                                 @endunless
                             </div>
                         </td>
@@ -366,6 +369,9 @@
                     </p>
                     @unless ($trashed)
                         <button type="button" class="btn btn-sm btn-outline-light" wire:click="resetFilters">Clear filters</button>
+                        @if (auth()->user()?->consoleAllows('setting', 'r'))
+                            <a href="{{ route('setup') }}" class="btn btn-sm btn-primary">Set up a client</a>
+                        @endif
                     @endunless
                 </div>
             @endforelse

--- a/resources/views/livewire/setup-wizard.blade.php
+++ b/resources/views/livewire/setup-wizard.blade.php
@@ -1,0 +1,80 @@
+<div wire:poll.10s="refreshDeviceStatus">
+    <div class="d-flex flex-wrap justify-content-between align-items-start gap-2 mb-3">
+        <div>
+            <h4 class="mb-1">Set up your first RustDesk device</h4>
+            <p class="text-muted mb-0">These values come from the same saved server settings used by CortenDesk's client API.</p>
+        </div>
+        @if (auth()->user()?->consoleAllows('setting', 'rw'))
+            <button type="button" class="btn btn-sm btn-outline-light" wire:click="dismiss">Do this later</button>
+        @endif
+    </div>
+
+    <div class="row g-3">
+        <div class="col-xl-8">
+            <div class="card">
+                <div class="card-header"><h5 class="card-title mb-0">1. Copy the client settings</h5></div>
+                <div class="card-body">
+                    @php
+                        $clientSettings = "ID Server: {$idServer}\nRelay Server: {$relayServer}\nAPI Server: {$apiUrl}\nKey: {$publicKey}";
+                    @endphp
+                    <div class="d-flex flex-wrap justify-content-between align-items-center gap-2 mb-3">
+                        <p class="mb-0">In RustDesk, open <strong>Settings → Network → ID/Relay Server</strong> and enter:</p>
+                        <button class="btn btn-sm btn-outline-light" type="button"
+                                onclick="navigator.clipboard.writeText(document.getElementById('client-settings-copy-all').value); this.setAttribute('aria-label', 'All client settings copied');">
+                            <i class="ri-file-copy-line me-1"></i>Copy all
+                        </button>
+                        <textarea id="client-settings-copy-all" class="visually-hidden" tabindex="-1" aria-hidden="true">{{ $clientSettings }}</textarea>
+                    </div>
+                    @foreach (['ID Server' => $idServer, 'Relay Server' => $relayServer, 'API Server' => $apiUrl, 'Key' => $publicKey] as $label => $value)
+                        <label class="form-label fs-13 text-muted mb-0">{{ $label }}</label>
+                        <div class="input-group input-group-sm mb-2">
+                            <input type="text" class="form-control rd-mono" readonly value="{{ $value }}">
+                            <button class="btn btn-light" type="button" title="Copy {{ $label }}"
+                                    onclick="navigator.clipboard.writeText(this.previousElementSibling.value); this.setAttribute('aria-label', '{{ $label }} copied');">
+                                <i class="ri-file-copy-line"></i><span class="visually-hidden">Copy {{ $label }}</span>
+                            </button>
+                        </div>
+                    @endforeach
+
+                    @if ($idServer === '' || $relayServer === '' || $apiUrl === '' || $publicKey === '')
+                        <div class="alert alert-warning mb-0 mt-3">
+                            One or more values are missing. <a class="alert-link" href="{{ route('settings', ['tab' => 'server']) }}">Complete Server settings</a> first.
+                        </div>
+                    @endif
+                </div>
+            </div>
+
+            <div class="card">
+                <div class="card-header"><h5 class="card-title mb-0">2. Confirm the first heartbeat</h5></div>
+                <div class="card-body">
+                    @if ($deviceConnected)
+                        <div class="alert alert-success mb-3"><i class="ri-check-line me-1"></i>A device has checked in.</div>
+                    @else
+                        <div class="alert alert-info mb-3"><i class="ri-loader-4-line me-1"></i>Waiting for a device to check in. This page checks every 10 seconds.</div>
+                    @endif
+                    @error('device')<div class="alert alert-danger">{{ $message }}</div>@enderror
+                    @if (auth()->user()?->consoleAllows('setting', 'rw'))
+                        <button type="button" class="btn btn-primary" wire:click="complete" @disabled(! $deviceConnected)>
+                            Finish setup
+                        </button>
+                    @endif
+                </div>
+            </div>
+        </div>
+
+        <div class="col-xl-4">
+            <div class="card">
+                <div class="card-header"><h5 class="card-title mb-0">3. Recommended security</h5></div>
+                <div class="card-body">
+                    <ul class="list-unstyled mb-0">
+                        <li class="mb-3"><i class="{{ $approvalEnabled ? 'ri-checkbox-circle-line text-success' : 'ri-error-warning-line text-warning' }} me-1"></i><strong>Device approval</strong><br><span class="text-muted fs-13">Hold new devices for review before they appear in the fleet.</span></li>
+                        <li><i class="{{ $twoFactorRequired ? 'ri-checkbox-circle-line text-success' : 'ri-error-warning-line text-warning' }} me-1"></i><strong>Administrator 2FA</strong><br><span class="text-muted fs-13">Protect console access with an authenticator and recovery codes.</span></li>
+                    </ul>
+                    @if (! $approvalEnabled || ! $twoFactorRequired)
+                        <a href="{{ route('settings', ['tab' => 'security']) }}" class="btn btn-sm btn-outline-light mt-3">Review security settings</a>
+                    @endif
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/resources/views/overview.blade.php
+++ b/resources/views/overview.blade.php
@@ -3,6 +3,13 @@
 @section('title', 'Overview')
 
 @section('content')
+    @if (\App\Livewire\SetupWizard::shouldPrompt(auth()->user()))
+        <div class="alert alert-info d-flex flex-wrap align-items-center gap-2">
+            <i class="ri-guide-line fs-20"></i>
+            <div class="flex-grow-1"><strong>Connect your first device.</strong> The setup guide provides the exact RustDesk network values and confirms the first heartbeat.</div>
+            <a href="{{ route('setup') }}" class="btn btn-sm btn-primary">Open setup guide</a>
+        </div>
+    @endif
     {{-- Only shown to someone who can actually fix it. Everything listed here
          is a feature that exists and silently cannot run without a relay. --}}
     @if (auth()->user()?->consoleAllows('setting', 'rw') && ! app(\App\Services\MailSettings::class)->isEnabled())

--- a/resources/views/setup/index.blade.php
+++ b/resources/views/setup/index.blade.php
@@ -1,0 +1,7 @@
+@extends('layouts.app')
+
+@section('title', 'First-run setup')
+
+@section('content')
+    @livewire(App\Livewire\SetupWizard::class)
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -105,6 +105,8 @@ Route::middleware('auth')->group(function () {
         ->middleware('console-can:user,r');
     Route::view('/settings', 'settings.index')->name('settings')
         ->middleware('console-can:setting,r');
+    Route::view('/setup', 'setup.index')->name('setup')
+        ->middleware('console-can:setting,r');
 
     // Login history and the console audit trail are the sensitive half of the
     // `audit` area, so they need "Manage" rather than "View".

--- a/tests/Feature/SetupWizardTest.php
+++ b/tests/Feature/SetupWizardTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Livewire\SetupWizard;
+use App\Models\Device;
+use App\Models\Setting;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class SetupWizardTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_only_users_with_settings_access_can_open_setup(): void
+    {
+        $admin = User::factory()->admin()->create();
+        $user = User::factory()->create();
+
+        $this->actingAs($admin)->get('/setup')->assertOk();
+        $this->actingAs($user)->get('/setup')->assertRedirect('/');
+    }
+
+    public function test_wizard_uses_canonical_client_values_and_never_displays_private_keys(): void
+    {
+        $admin = User::factory()->admin()->create();
+        Setting::put('id_server', 'id.example.test:21116');
+        Setting::put('relay_server', 'relay.example.test:21117');
+        Setting::put('public_key', 'PUBLIC_KEY');
+        config(['app.url' => 'https://desk.example.test']);
+
+        Livewire::actingAs($admin)
+            ->test(SetupWizard::class)
+            ->assertSee('id.example.test:21116')
+            ->assertSee('relay.example.test:21117')
+            ->assertSee('https://desk.example.test')
+            ->assertSee('PUBLIC_KEY')
+            ->assertSee('Copy all')
+            ->assertSee('ID Server: id.example.test:21116')
+            ->assertDontSee('APP_KEY')
+            ->assertDontSee('id_ed25519');
+    }
+
+    public function test_fresh_empty_install_is_prompted_and_dismissal_is_persisted(): void
+    {
+        $admin = User::factory()->admin()->create();
+        $this->assertTrue(SetupWizard::shouldPrompt($admin));
+
+        Livewire::actingAs($admin)->test(SetupWizard::class)->call('dismiss');
+
+        $this->assertNotNull($admin->fresh()->setup_wizard_dismissed_at);
+        $this->assertFalse(SetupWizard::shouldPrompt($admin->fresh()));
+    }
+
+    public function test_a_device_record_without_a_heartbeat_does_not_complete_setup(): void
+    {
+        $admin = User::factory()->admin()->create();
+        Device::create(['rustdesk_id' => '123456', 'uuid' => 'imported-only']);
+
+        Livewire::actingAs($admin)
+            ->test(SetupWizard::class)
+            ->assertSet('deviceConnected', false)
+            ->call('complete')
+            ->assertHasErrors('device');
+
+        $this->assertNull($admin->fresh()->setup_wizard_completed_at);
+    }
+
+    public function test_first_device_heartbeat_completes_the_wizard(): void
+    {
+        $admin = User::factory()->admin()->create();
+        Device::create(['rustdesk_id' => '123456', 'uuid' => 'uuid-1', 'last_online_at' => now()]);
+
+        Livewire::actingAs($admin)
+            ->test(SetupWizard::class)
+            ->assertSet('deviceConnected', true)
+            ->call('complete');
+
+        $this->assertNotNull($admin->fresh()->setup_wizard_completed_at);
+        $this->assertFalse(SetupWizard::shouldPrompt($admin->fresh()));
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Tests;
+
+use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
+
+abstract class TestCase extends BaseTestCase {}


### PR DESCRIPTION
## Summary

- Adds a permission-gated first-run setup wizard for connecting the first RustDesk device.
- Shows the canonical ID server, relay server, API server, and public key values already used by CortenDesk.
- Provides individual copy controls and a privacy-safe Copy all bundle.
- Waits for an actual device heartbeat before allowing setup completion.
- Persists completion or dismissal per administrator and adds entry points to the overview and empty device inventory.
- Highlights recommended device-approval and administrator-2FA settings.

## Safety and compatibility

- Displays only public client configuration; application keys and private RustDesk keys are excluded.
- Existing installations are not forced into the wizard.
- Imported/manual device records without a heartbeat do not falsely complete setup.
- Authorization follows the existing delegated settings permission.

## Testing

- `php artisan test --compact` — 5 tests, 22 assertions passed
- `php artisan view:cache`
- Pint checks for all changed PHP files
- `git diff --check origin/main...HEAD`
