### PR TITLE
feat: add fleet health diagnostics

### DIFF
--- a/app/Console/Commands/DiagnosticsHeartbeat.php
+++ b/app/Console/Commands/DiagnosticsHeartbeat.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Cache;
+
+class DiagnosticsHeartbeat extends Command
+{
+    protected $signature = 'cortendesk:diagnostics-heartbeat';
+
+    protected $description = 'Record scheduler freshness for Fleet Diagnostics';
+
+    public function handle(): int
+    {
+        Cache::forever('cortendesk:diagnostics:scheduler-heartbeat', now()->toIso8601String());
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Contracts/TcpProbe.php
+++ b/app/Contracts/TcpProbe.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Contracts;
+
+interface TcpProbe
+{
+    /** @return array{ok: bool, latency_ms: int|null, error: string|null} */
+    public function check(string $host, int $port, float $timeout): array;
+}

--- a/app/Http/Controllers/DiagnosticsController.php
+++ b/app/Http/Controllers/DiagnosticsController.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Services\FleetDiagnostics;
+use Illuminate\View\View;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+class DiagnosticsController extends Controller
+{
+    public function index(FleetDiagnostics $diagnostics): View
+    {
+        return view('diagnostics.index', ['report' => $diagnostics->report()]);
+    }
+
+    public function export(FleetDiagnostics $diagnostics): StreamedResponse
+    {
+        return response()->streamDownload(function () use ($diagnostics): void {
+            echo json_encode($diagnostics->sanitized(), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+        }, 'cortendesk-diagnostics.json', [
+            'Cache-Control' => 'no-store, private',
+            'Content-Type' => 'application/json',
+        ]);
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,8 +2,10 @@
 
 namespace App\Providers;
 
+use App\Contracts\TcpProbe;
 use App\Models\ApiToken;
 use App\Models\ClientToken;
+use App\Services\SocketTcpProbe;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\ServiceProvider;
@@ -15,7 +17,7 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-        //
+        $this->app->bind(TcpProbe::class, SocketTcpProbe::class);
     }
 
     /**

--- a/app/Services/FleetDiagnostics.php
+++ b/app/Services/FleetDiagnostics.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace App\Services;
+
+use App\Contracts\TcpProbe;
+use App\Models\Device;
+use App\Models\Setting;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
+use Throwable;
+
+class FleetDiagnostics
+{
+    public function __construct(private TcpProbe $tcp) {}
+
+    public function report(): array
+    {
+        $database = true;
+        try {
+            DB::select('select 1');
+        } catch (Throwable) {
+            $database = false;
+        }
+
+        $versions = Device::query()->approved()
+            ->selectRaw("COALESCE(NULLIF(version, ''), 'unknown') as version, COUNT(*) as count")
+            ->groupBy('version')->orderByDesc('count')->get()
+            ->map(fn ($row) => ['version' => (string) $row->version, 'count' => (int) $row->count])->all();
+        $known = array_values(array_filter(array_column($versions, 'version'), fn ($version) => $version !== 'unknown'));
+        usort($known, 'version_compare');
+        $newest = $known === [] ? null : end($known);
+
+        $schedulerAt = Cache::get('cortendesk:diagnostics:scheduler-heartbeat');
+        try {
+            $schedulerFresh = is_string($schedulerAt) && now()->diffInMinutes($schedulerAt, true) <= 3;
+        } catch (Throwable) {
+            $schedulerFresh = false;
+            $schedulerAt = null;
+        }
+
+        $websocketIdConfigured = trim((string) config('cortendesk.ws_id_url')) !== '';
+        $websocketRelayConfigured = trim((string) config('cortendesk.ws_relay_url')) !== '';
+        $mail = app(MailSettings::class);
+        $smtpConfigured = $mail->isConfigured();
+        $smtpObserved = trim((string) Setting::get('smtp_ok_at', '')) !== ''
+            || trim((string) Setting::get('smtp_failed_at', '')) !== '';
+
+        return [
+            'generated_at' => now()->toIso8601String(),
+            'application' => ['ok' => true, 'version' => (string) config('cortendesk.api_version')],
+            'database' => ['ok' => $database],
+            'services' => [
+                'id_server' => $this->serverProbe('id_server', 21116),
+                'relay_server' => $this->serverProbe('relay_server', 21117),
+                'api' => ['ok' => true, 'mode' => 'local route', 'version_route' => '/api/version'],
+                'websocket_bridge' => [
+                    'ok' => (bool) config('cortendesk.native_webclient') && $websocketIdConfigured && $websocketRelayConfigured,
+                    'id_configured' => $websocketIdConfigured,
+                    'relay_configured' => $websocketRelayConfigured,
+                    'note' => 'Readiness only; remote WebSocket endpoints are not contacted.',
+                ],
+            ],
+            'scheduler' => ['ok' => $schedulerFresh, 'last_seen_at' => $schedulerAt],
+            'fleet' => [
+                'total' => Device::query()->approved()->count(),
+                'online' => Device::query()->approved()->online()->count(),
+                'offline' => Device::query()->approved()->offline()->count(),
+                'pending' => Device::query()->pending()->count(),
+                'silent_over_24h' => Device::query()->approved()
+                    ->where(fn ($query) => $query->whereNull('last_online_at')->orWhere('last_online_at', '<', now()->subDay()))
+                    ->count(),
+                'latest_heartbeat_at' => Device::query()->approved()->max('last_online_at'),
+                'versions' => array_map(fn ($row) => $row + [
+                    'status' => $newest !== null && $row['version'] !== 'unknown' && version_compare($row['version'], $newest, '<')
+                        ? 'Behind newest fleet version' : 'Newest or unknown',
+                ], $versions),
+                'newest_reported_version' => $newest,
+            ],
+            'smtp' => [
+                'configured' => $smtpConfigured,
+                'enabled' => $mail->isEnabled(),
+                'healthy' => $smtpConfigured && $smtpObserved ? $mail->isHealthy() : null,
+                'note' => match (true) {
+                    ! $smtpConfigured => 'SMTP is not configured. No message is sent automatically.',
+                    ! $smtpObserved => 'Configured, but no send result has been observed. No message is sent automatically.',
+                    default => 'Health reflects the last observed send. No message is sent automatically.',
+                },
+            ],
+        ];
+    }
+
+    public function sanitized(): array
+    {
+        $report = $this->report();
+
+        foreach (['id_server', 'relay_server'] as $name) {
+            $report['services'][$name] = [
+                'configured' => $report['services'][$name]['configured'],
+                'port' => $report['services'][$name]['port'],
+                'ok' => $report['services'][$name]['ok'],
+                'latency_ms' => $report['services'][$name]['latency_ms'],
+            ];
+        }
+
+        return $report;
+    }
+
+    private function serverProbe(string $key, int $defaultPort): array
+    {
+        [$host, $port] = $this->parseServer((string) Setting::get($key, config('cortendesk.'.$key)), $defaultPort);
+        if ($host === '') {
+            return ['configured' => false, 'port' => $defaultPort, 'ok' => false, 'latency_ms' => null, 'error' => 'Not configured.'];
+        }
+
+        return ['configured' => true, 'port' => $port, 'host_label' => $this->hostLabel($host)]
+            + $this->tcp->check($host, $port, 1.0);
+    }
+
+    private function parseServer(string $value, int $defaultPort): array
+    {
+        $value = trim($value);
+        if ($value === '') {
+            return ['', $defaultPort];
+        }
+        $parts = parse_url(str_contains($value, '://') ? $value : 'tcp://'.$value);
+
+        return [(string) ($parts['host'] ?? ''), (int) ($parts['port'] ?? $defaultPort)];
+    }
+
+    private function hostLabel(string $host): string
+    {
+        return filter_var($host, FILTER_VALIDATE_IP) ? 'configured IP address' : 'configured hostname';
+    }
+}

--- a/app/Services/FleetDiagnostics.php
+++ b/app/Services/FleetDiagnostics.php
@@ -38,8 +38,10 @@ class FleetDiagnostics
             $schedulerAt = null;
         }
 
-        $websocketIdConfigured = trim((string) config('cortendesk.ws_id_url')) !== '';
-        $websocketRelayConfigured = trim((string) config('cortendesk.ws_relay_url')) !== '';
+        $appHostConfigured = filter_var((string) config('app.url'), FILTER_VALIDATE_URL) !== false
+            && parse_url((string) config('app.url'), PHP_URL_HOST) !== null;
+        $websocketIdConfigured = trim((string) config('cortendesk.ws_id_url')) !== '' || $appHostConfigured;
+        $websocketRelayConfigured = trim((string) config('cortendesk.ws_relay_url')) !== '' || $appHostConfigured;
         $mail = app(MailSettings::class);
         $smtpConfigured = $mail->isConfigured();
         $smtpObserved = trim((string) Setting::get('smtp_ok_at', '')) !== ''
@@ -57,7 +59,7 @@ class FleetDiagnostics
                     'ok' => (bool) config('cortendesk.native_webclient') && $websocketIdConfigured && $websocketRelayConfigured,
                     'id_configured' => $websocketIdConfigured,
                     'relay_configured' => $websocketRelayConfigured,
-                    'note' => 'Readiness only; remote WebSocket endpoints are not contacted.',
+                    'note' => 'Readiness only; explicit endpoints or the APP_URL same-origin fallback are accepted. Remote endpoints are not contacted.',
                 ],
             ],
             'scheduler' => ['ok' => $schedulerFresh, 'last_seen_at' => $schedulerAt],

--- a/app/Services/SocketTcpProbe.php
+++ b/app/Services/SocketTcpProbe.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Services;
+
+use App\Contracts\TcpProbe;
+
+class SocketTcpProbe implements TcpProbe
+{
+    public function check(string $host, int $port, float $timeout): array
+    {
+        $started = microtime(true);
+        $errno = 0;
+        $error = '';
+        $socket = @stream_socket_client("tcp://{$host}:{$port}", $errno, $error, $timeout);
+        $latency = (int) round((microtime(true) - $started) * 1000);
+
+        if (is_resource($socket)) {
+            fclose($socket);
+
+            return ['ok' => true, 'latency_ms' => $latency, 'error' => null];
+        }
+
+        return ['ok' => false, 'latency_ms' => $latency, 'error' => $errno ? 'Connection failed ('.$errno.').' : 'Connection failed.'];
+    }
+}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php" colors="true">
+    <testsuites><testsuite name="Feature"><directory>tests/Feature</directory></testsuite></testsuites>
+    <php>
+        <env name="APP_ENV" value="testing"/><env name="APP_KEY" value="base64:RS1QLhuuYPHOBOwym/pch/YMJbc+FyZrwFNZHaogPqQ="/>
+        <env name="BCRYPT_ROUNDS" value="4"/><env name="CACHE_STORE" value="array"/>
+        <env name="DB_CONNECTION" value="sqlite"/><env name="DB_DATABASE" value=":memory:"/>
+        <env name="MAIL_MAILER" value="array"/><env name="QUEUE_CONNECTION" value="sync"/><env name="SESSION_DRIVER" value="array"/>
+    </php>
+</phpunit>

--- a/resources/views/diagnostics/index.blade.php
+++ b/resources/views/diagnostics/index.blade.php
@@ -1,0 +1,85 @@
+@extends('layouts.app')
+
+@section('title', 'Fleet diagnostics')
+
+@section('content')
+    <div class="d-flex flex-wrap justify-content-between align-items-start gap-2 mb-3">
+        <div>
+            <h4 class="mb-1">Fleet diagnostics</h4>
+            <p class="text-muted mb-0">Bounded probes and fleet signals. No test email is sent automatically.</p>
+        </div>
+        <a href="{{ route('diagnostics.export') }}" class="btn btn-sm btn-outline-light">
+            <i class="ri-download-2-line me-1"></i>Sanitized JSON
+        </a>
+    </div>
+
+    @php
+        $checks = [
+            ['label' => 'Application', 'ok' => $report['application']['ok'], 'detail' => 'CortenDesk v'.$report['application']['version']],
+            ['label' => 'Database', 'ok' => $report['database']['ok'], 'detail' => $report['database']['ok'] ? 'Query completed.' : 'Query failed.'],
+            ['label' => 'ID server', 'ok' => $report['services']['id_server']['ok'], 'detail' => $report['services']['id_server']['configured'] ? $report['services']['id_server']['host_label'].' on port '.$report['services']['id_server']['port'] : 'Not configured.'],
+            ['label' => 'Relay server', 'ok' => $report['services']['relay_server']['ok'], 'detail' => $report['services']['relay_server']['configured'] ? $report['services']['relay_server']['host_label'].' on port '.$report['services']['relay_server']['port'] : 'Not configured.'],
+            ['label' => 'Public API', 'ok' => $report['services']['api']['ok'], 'detail' => 'Local version route '.$report['services']['api']['version_route'].' is registered.'],
+            ['label' => 'WebSocket bridge', 'ok' => $report['services']['websocket_bridge']['ok'], 'detail' => $report['services']['websocket_bridge']['note']],
+            ['label' => 'Scheduler', 'ok' => $report['scheduler']['ok'], 'detail' => $report['scheduler']['ok'] ? 'Heartbeat is fresh.' : 'No fresh scheduler heartbeat.'],
+            ['label' => 'SMTP', 'ok' => $report['smtp']['configured'] ? $report['smtp']['healthy'] : null, 'detail' => $report['smtp']['note']],
+        ];
+    @endphp
+
+    <div class="row g-3">
+        @foreach ($checks as $check)
+            @php
+                $status = $check['ok'] === null ? 'unknown' : ($check['ok'] ? 'ok' : 'failed');
+                $tone = $status === 'ok' ? 'success' : ($status === 'failed' ? 'danger' : 'secondary');
+            @endphp
+            <div class="col-md-6 col-xl-4">
+                <div class="card h-100">
+                    <div class="card-body">
+                        <div class="d-flex justify-content-between gap-2">
+                            <strong>{{ $check['label'] }}</strong>
+                            <span class="badge bg-{{ $tone }}-subtle text-{{ $tone }}">{{ ucfirst($status) }}</span>
+                        </div>
+                        <p class="text-muted fs-13 mb-0 mt-2">{{ $check['detail'] }}</p>
+                    </div>
+                </div>
+            </div>
+        @endforeach
+    </div>
+
+    <div class="card mt-3">
+        <div class="card-header"><h5 class="card-title mb-0">Fleet summary</h5></div>
+        <div class="card-body">
+            <div class="row g-3 mb-3">
+                @foreach (['total' => 'Devices', 'online' => 'Online', 'offline' => 'Offline', 'silent_over_24h' => 'Silent 24h+', 'pending' => 'Pending'] as $key => $label)
+                    <div class="col-6 col-lg">
+                        <div class="text-muted fs-13">{{ $label }}</div>
+                        <div class="fs-4 fw-semibold">{{ $report['fleet'][$key] }}</div>
+                    </div>
+                @endforeach
+            </div>
+
+            <p class="text-muted fs-13">
+                Version status is relative to the newest client currently reporting in this fleet, not a vendor release feed.
+            </p>
+
+            @if ($report['fleet']['versions'])
+                <div class="table-responsive">
+                    <table class="table table-sm mb-0">
+                        <thead><tr><th>Client version</th><th>Devices</th><th>Status</th></tr></thead>
+                        <tbody>
+                            @foreach ($report['fleet']['versions'] as $version)
+                                <tr>
+                                    <td class="rd-mono">{{ $version['version'] }}</td>
+                                    <td>{{ $version['count'] }}</td>
+                                    <td>{{ $version['status'] }}</td>
+                                </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+                </div>
+            @else
+                <p class="text-muted mb-0">No client versions have been reported.</p>
+            @endif
+        </div>
+    </div>
+@endsection

--- a/resources/views/layouts/partials/sidebar.blade.php
+++ b/resources/views/layouts/partials/sidebar.blade.php
@@ -164,6 +164,13 @@
                     </a>
                 </li>
 
+                <li class="side-nav-item {{ request()->routeIs('diagnostics*') ? 'menuitem-active' : '' }}">
+                    <a href="{{ route('diagnostics') }}" class="side-nav-link {{ request()->routeIs('diagnostics*') ? 'active' : '' }}">
+                        <i class="ri-pulse-line"></i>
+                        <span> Diagnostics </span>
+                    </a>
+                </li>
+
                 @php
                     $rdgenUrl = \App\Models\Setting::get('rdgen_url', config('cortendesk.rdgen_url'));
                 @endphp

--- a/routes/console.php
+++ b/routes/console.php
@@ -18,3 +18,4 @@ Schedule::command('cortendesk:prune-invitations')->dailyAt('04:20');
 // Sessions on devices that have gone silent (issue #10). Frequent, not nightly:
 // this drives what the dashboard reports as happening right now.
 Schedule::command('cortendesk:close-stale-sessions')->everyFiveMinutes()->withoutOverlapping();
+Schedule::command('cortendesk:diagnostics-heartbeat')->everyMinute()->withoutOverlapping();

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,6 +4,7 @@ use App\Http\Controllers\Api\ClientOidcController;
 use App\Http\Controllers\Api\WebClientController;
 use App\Http\Controllers\AuthController;
 use App\Http\Controllers\DashboardController;
+use App\Http\Controllers\DiagnosticsController;
 use App\Http\Controllers\InvitationController;
 use App\Http\Controllers\OidcController;
 use App\Http\Controllers\PasswordResetController;
@@ -104,6 +105,10 @@ Route::middleware('auth')->group(function () {
     Route::view('/users', 'users.index')->name('users')
         ->middleware('console-can:user,r');
     Route::view('/settings', 'settings.index')->name('settings')
+        ->middleware('console-can:setting,r');
+    Route::get('/diagnostics', [DiagnosticsController::class, 'index'])->name('diagnostics')
+        ->middleware('console-can:setting,r');
+    Route::get('/diagnostics/export', [DiagnosticsController::class, 'export'])->name('diagnostics.export')
         ->middleware('console-can:setting,r');
 
     // Login history and the console audit trail are the sensitive half of the

--- a/tests/Feature/DiagnosticsHeartbeatTest.php
+++ b/tests/Feature/DiagnosticsHeartbeatTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Services\FleetDiagnostics;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+use Tests\TestCase;
+
+class DiagnosticsHeartbeatTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_scheduler_heartbeat_command_updates_the_cache(): void
+    {
+        Cache::forget('cortendesk:diagnostics:scheduler-heartbeat');
+
+        $this->artisan('cortendesk:diagnostics-heartbeat')->assertExitCode(0);
+
+        $this->assertNotNull(Cache::get('cortendesk:diagnostics:scheduler-heartbeat'));
+    }
+
+    public function test_invalid_scheduler_heartbeat_is_treated_as_stale(): void
+    {
+        Cache::put('cortendesk:diagnostics:scheduler-heartbeat', 'not-a-date');
+
+        $report = app(FleetDiagnostics::class)->report();
+
+        $this->assertFalse($report['scheduler']['ok']);
+        $this->assertNull($report['scheduler']['last_seen_at']);
+    }
+}

--- a/tests/Feature/FleetDiagnosticsTest.php
+++ b/tests/Feature/FleetDiagnosticsTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Contracts\TcpProbe;
+use App\Models\Device;
+use App\Models\Setting;
+use App\Models\User;
+use App\Services\FleetDiagnostics;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+use Tests\TestCase;
+
+class FleetDiagnosticsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_diagnostics_is_permission_gated_and_uses_bounded_injected_tcp_probes(): void
+    {
+        $admin = User::factory()->admin()->create();
+        $user = User::factory()->create();
+        Setting::put('id_server', '10.0.0.5:21116');
+        Setting::put('relay_server', 'relay.secret.test:21117');
+
+        $fake = new class implements TcpProbe
+        {
+            public array $calls = [];
+
+            public function check(string $host, int $port, float $timeout): array
+            {
+                $this->calls[] = [$host, $port, $timeout];
+
+                return ['ok' => true, 'latency_ms' => 3, 'error' => null];
+            }
+        };
+        $this->app->instance(TcpProbe::class, $fake);
+
+        $this->actingAs($admin)->get('/diagnostics')->assertOk()->assertSee('Fleet diagnostics');
+        $this->actingAs($user)->get('/diagnostics')->assertRedirect('/');
+
+        $this->assertSame([
+            ['10.0.0.5', 21116, 1.0],
+            ['relay.secret.test', 21117, 1.0],
+        ], $fake->calls);
+    }
+
+    public function test_report_includes_fleet_scheduler_mail_and_version_signals(): void
+    {
+        $this->assertNull(app(FleetDiagnostics::class)->report()['smtp']['healthy']);
+
+        $admin = User::factory()->admin()->create();
+        Setting::put('smtp_enabled', '1');
+        Setting::put('smtp_host', 'smtp.secret.test');
+        Setting::put('smtp_from_address', 'desk@example.test');
+        Cache::forever('cortendesk:diagnostics:scheduler-heartbeat', now()->toIso8601String());
+
+        Device::create(['rustdesk_id' => '1', 'uuid' => 'one', 'status' => Device::STATUS_ACTIVE, 'version' => '1.4.0', 'last_online_at' => now()]);
+        Device::create(['rustdesk_id' => '2', 'uuid' => 'two', 'status' => Device::STATUS_ACTIVE, 'version' => '1.3.0', 'last_online_at' => now()->subDays(2)]);
+
+        $this->actingAs($admin)->get('/diagnostics')
+            ->assertOk()
+            ->assertSee('Scheduler')
+            ->assertSee('SMTP')
+            ->assertSee('Configured, but no send result has been observed.')
+            ->assertSee('1.4.0')
+            ->assertSee('Behind newest fleet version');
+
+        $report = app(FleetDiagnostics::class)->report();
+        $this->assertNull($report['smtp']['healthy']);
+        $this->assertSame(1, $report['fleet']['silent_over_24h']);
+        $this->assertFalse($report['services']['websocket_bridge']['ok']);
+    }
+
+    public function test_sanitized_export_excludes_hosts_ips_urls_and_keys(): void
+    {
+        $admin = User::factory()->admin()->create();
+        Setting::put('id_server', '10.0.0.5:21116');
+        Setting::put('relay_server', 'relay.secret.test:21117');
+        Setting::put('public_key', 'VERY_SECRET_PUBLIC_KEY');
+        config(['app.url' => 'https://desk.secret.test']);
+
+        $response = $this->actingAs($admin)->get('/diagnostics/export')->assertOk();
+        $response->assertHeader('Cache-Control', 'no-store, private');
+        $json = $response->streamedContent();
+
+        $this->assertStringNotContainsString('10.0.0.5', $json);
+        $this->assertStringNotContainsString('relay.secret.test', $json);
+        $this->assertStringNotContainsString('desk.secret.test', $json);
+        $this->assertStringNotContainsString('VERY_SECRET_PUBLIC_KEY', $json);
+        $this->assertStringContainsString('id_server', $json);
+        $this->assertStringContainsString('configured', $json);
+    }
+}

--- a/tests/Feature/FleetDiagnosticsTest.php
+++ b/tests/Feature/FleetDiagnosticsTest.php
@@ -68,7 +68,10 @@ class FleetDiagnosticsTest extends TestCase
         $report = app(FleetDiagnostics::class)->report();
         $this->assertNull($report['smtp']['healthy']);
         $this->assertSame(1, $report['fleet']['silent_over_24h']);
-        $this->assertFalse($report['services']['websocket_bridge']['ok']);
+        $this->assertTrue($report['services']['websocket_bridge']['ok']);
+
+        config(['app.url' => '', 'cortendesk.ws_id_url' => '', 'cortendesk.ws_relay_url' => '']);
+        $this->assertFalse(app(FleetDiagnostics::class)->report()['services']['websocket_bridge']['ok']);
     }
 
     public function test_sanitized_export_excludes_hosts_ips_urls_and_keys(): void

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Tests;
+
+use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
+
+abstract class TestCase extends BaseTestCase {}


### PR DESCRIPTION
## Summary

- Adds a permission-gated Fleet diagnostics page and sanitized JSON export.
- Uses bounded TCP probes for configured ID and relay servers.
- Reports application, database, local API, WebSocket readiness, scheduler heartbeat, and SMTP observed state.
- Summarizes approved, online, offline, pending, and silent-over-24-hours devices.
- Shows client-version distribution and clearly labels comparison as relative to the newest version reported by the current fleet.

## Privacy and accuracy

- The JSON export excludes configured hosts, IP addresses, public URLs, public keys, SMTP identity, and device identities.
- Exports use `Cache-Control: no-store, private`.
- WebSocket status is readiness-only; it does not claim a remote connection test.
- SMTP health is unknown until a send result has actually been observed.
- TCP probes use a one-second timeout and scheduler timestamps are handled defensively.

## Testing

- `php artisan test --compact` — 5 tests, 29 assertions passed
- `php artisan view:cache`
- Pint checks for all changed PHP files
- `git diff --check origin/main...HEAD`
