### PR TITLE
Client Downloads: publish custom client builds on the sign-in page

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Built on Laravel + Livewire with precompiled assets: **there is no frontend buil
 - **Two-factor authentication** — TOTP with single-use recovery codes, optionally required for everyone or for administrators only, with an administrator reset and a break-glass command.
 - **Delegated administration** — roles with a permission matrix over each console area, so you can grant someone the users screen without handing them the whole console.
 - **Automation API** — scoped bearer tokens and a REST API for users, devices, groups, address books and audit logs, plus support for the RustDesk client's `--assign` flag for unattended deployment.
+- **Client downloads** — upload the custom installers you built (rdgen or otherwise) and CortenDesk publishes them with the right platform icon, read off the filename and overridable per build. They appear under the sign-in form and on a public `/downloads` page you can send to somebody who has no console account. Files are stored in the `/data` volume (`CORTENDESK_DOWNLOADS_PATH`) and streamed as attachments, never as static paths.
 - **Email** — SMTP settings with a test send, user invitations by email, self-service password reset, and an optional emailed code when signing in from a new browser.
 - **Dashboard** — live stat tiles, active sessions, 14-day connection charts, platform and version breakdowns.
 - **Importer** — one artisan command migrates everything (users with passwords intact, devices, address books, audit history) from a `lejianwen/rustdesk-api` database.
@@ -123,6 +124,11 @@ DB_PASSWORD=********
 CORTENDESK_ID_SERVER=hbbs.example.com:21116
 CORTENDESK_RELAY_SERVER=hbbs.example.com:21117
 CORTENDESK_PUBLIC_KEY=<contents of your id_ed25519.pub>
+
+# Client downloads (defaults to /data/downloads in Docker; keep the size limit
+# below post_max_size / client_max_body_size)
+CORTENDESK_DOWNLOADS_PATH=/data/downloads
+CORTENDESK_DOWNLOADS_MAX_KB=30720
 
 # Native web client (wss endpoints your proxy exposes, see below)
 CORTENDESK_NATIVE_WEBCLIENT=true

--- a/app/Http/Controllers/ClientDownloadController.php
+++ b/app/Http/Controllers/ClientDownloadController.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\ClientDownload;
+use App\Support\ClientPlatform;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\View\View;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+use Throwable;
+
+/**
+ * The public client-download page and file streamer.
+ *
+ * Both routes are deliberately unauthenticated (routes/web.php): the whole
+ * point is a link an operator can send to somebody who has no console account,
+ * and the sign-in page shows the same icons for a technician standing at a
+ * fresh machine. What that costs is that anything published here is public, so:
+ *
+ *   - only is_published rows are ever visible or fetchable;
+ *   - the row is looked up by primary key, never by a path from the request,
+ *     so there is no traversal surface;
+ *   - the response is always an attachment with nosniff, so an uploaded file
+ *     can never be coaxed into executing in the browser;
+ *   - both routes are throttled (see the route definitions).
+ */
+class ClientDownloadController extends Controller
+{
+    public function index(): View
+    {
+        return view('downloads.index', [
+            'downloads' => ClientDownload::published()->ordered()->get()
+                ->sortBy(fn (ClientDownload $d) => array_search($d->platform, ClientPlatform::PLATFORMS, true))
+                ->values(),
+        ]);
+    }
+
+    public function show(ClientDownload $download): StreamedResponse
+    {
+        // Route-model binding does not know about the scope, and an
+        // unpublished build must be a 404 rather than a 403 — an outsider
+        // learns nothing about what is staged.
+        abort_unless($download->is_published, 404);
+
+        $disk = Storage::disk(ClientDownload::DISK);
+
+        abort_unless($disk->exists($download->filename), 404);
+
+        // Not a real counter (no locking, and a resumed download counts twice);
+        // it exists so an operator can see which build people actually take.
+        // Never at the expense of the download itself: this is the only write on
+        // an otherwise read-only public route, so a read-only replica, a locked
+        // SQLite file or a full disk would turn every install attempt into a
+        // 500. Report and hand over the file.
+        try {
+            $download->increment('download_count');
+        } catch (Throwable $e) {
+            report($e);
+        }
+
+        return $disk->download($download->filename, $download->original_name, [
+            'Content-Type' => 'application/octet-stream',
+            'X-Content-Type-Options' => 'nosniff',
+        ]);
+    }
+}

--- a/app/Livewire/ClientDownloadManager.php
+++ b/app/Livewire/ClientDownloadManager.php
@@ -1,0 +1,329 @@
+<?php
+
+namespace App\Livewire;
+
+use App\Livewire\Concerns\AuthorizesConsole;
+use App\Models\ClientDownload;
+use App\Models\ConsoleAudit;
+use App\Support\ClientPlatform;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Livewire\Component;
+use Livewire\WithFileUploads;
+
+/**
+ * Client Downloads — upload the installers rdgen built and publish them on the
+ * sign-in page.
+ *
+ * Permissions: this screen is part of the `setting` area rather than an area of
+ * its own. Areas are a fixed matrix (App\Support\Permissions::CONSOLE_RESOURCES,
+ * mirrored by Role and the API-token grid), and "who may publish a download the
+ * whole internet can fetch" is the same trust level as "who may edit server
+ * settings" — so it reuses `setting` instead of widening that matrix.
+ *
+ * mount() checks View; every mutator re-checks Manage, because /livewire/update
+ * is directly reachable (see the AuthorizesConsole docblock).
+ */
+class ClientDownloadManager extends Component
+{
+    use AuthorizesConsole;
+    use WithFileUploads;
+
+    public bool $showModal = false;
+
+    /** null = uploading a new build, otherwise the row being edited. */
+    public ?int $editing = null;
+
+    /**
+     * The pending upload. Deliberately untyped: Livewire hydrates it as a
+     * TemporaryUploadedFile only while one is staged, and null the rest of the
+     * time.
+     */
+    public $file = null;
+
+    public string $label = '';
+
+    public string $platform = 'unknown';
+
+    public string $arch = '';
+
+    public string $version = '';
+
+    public string $notes = '';
+
+    public bool $isPublished = true;
+
+    /**
+     * Set once the operator edits the label or platform by hand, so a later
+     * file pick (a "replace file" on an existing row) cannot silently
+     * overwrite what they typed.
+     */
+    public bool $touchedLabel = false;
+
+    public bool $touchedPlatform = false;
+
+    public function mount(): void
+    {
+        $this->authorizeConsole('setting', 'r');
+    }
+
+    public function create(): void
+    {
+        $this->authorizeConsole('setting', 'rw');
+
+        $this->resetForm();
+        $this->showModal = true;
+    }
+
+    public function edit(int $id): void
+    {
+        $this->authorizeConsole('setting', 'rw');
+
+        $this->resetForm();
+
+        $download = ClientDownload::findOrFail($id);
+        $this->editing = $download->id;
+        $this->label = $download->label;
+        $this->platform = $download->platform;
+        $this->arch = $download->arch ?? '';
+        $this->version = $download->version ?? '';
+        $this->notes = $download->notes ?? '';
+        $this->isPublished = $download->is_published;
+        // An existing row already has its bytes; the file input is a replace.
+        $this->touchedLabel = true;
+        $this->touchedPlatform = true;
+
+        $this->showModal = true;
+    }
+
+    /**
+     * Auto-detect from the filename the moment a file is picked. This is the
+     * "detect the platform icon from the file name" half of the feature; the
+     * dropdown in the modal is the override, and anything the operator has
+     * already typed is left alone.
+     */
+    public function updatedFile(): void
+    {
+        $this->authorizeConsole('setting', 'rw');
+
+        if (! $this->file) {
+            return;
+        }
+
+        $name = $this->file->getClientOriginalName();
+
+        if (! $this->touchedPlatform) {
+            $this->platform = ClientPlatform::fromFilename($name);
+        }
+
+        if (! $this->touchedLabel) {
+            $this->label = ClientPlatform::labelFromFilename($name);
+        }
+
+        if ($this->arch === '') {
+            $this->arch = ClientPlatform::archFromFilename($name) ?? '';
+        }
+    }
+
+    public function updatedLabel(): void
+    {
+        $this->touchedLabel = true;
+    }
+
+    public function updatedPlatform(): void
+    {
+        $this->touchedPlatform = true;
+    }
+
+    public function save(): void
+    {
+        $this->authorizeConsole('setting', 'rw');
+
+        $maxKb = self::maxKilobytes();
+
+        $this->validate([
+            // Required only for a new row: editing without picking a file keeps
+            // the bytes that are already there.
+            'file' => [$this->editing ? 'nullable' : 'required', 'file', 'max:'.$maxKb, function ($attribute, $value, $fail) {
+                if ($value && ! ClientPlatform::extensionAllowed($value->getClientOriginalName())) {
+                    $fail('That file type is not an installer CortenDesk will hand out. Allowed: '
+                        .implode(', ', ClientPlatform::allowedExtensions()).'.');
+                }
+            }],
+            'label' => ['required', 'string', 'max:120'],
+            'platform' => ['required', 'in:'.implode(',', ClientPlatform::PLATFORMS)],
+            'arch' => ['nullable', 'string', 'max:32'],
+            'version' => ['nullable', 'string', 'max:64'],
+            'notes' => ['nullable', 'string', 'max:500'],
+        ], [
+            'file.max' => 'That build is larger than the '.round($maxKb / 1024).' MB upload limit. '
+                .'Raise upload_max_filesize/post_max_size in docker/php.ini and client_max_body_size '
+                .'in docker/nginx.conf.template together, then CORTENDESK_DOWNLOADS_MAX_KB.',
+        ]);
+
+        $download = $this->editing ? ClientDownload::findOrFail($this->editing) : new ClientDownload;
+
+        // Replacing a file: drop the old bytes only once the new ones are
+        // safely written, and never before (a failed store would otherwise
+        // leave the row pointing at nothing).
+        $previous = $download->filename;
+
+        if ($this->file) {
+            $original = $this->file->getClientOriginalName();
+            $stored = $this->storedName($original);
+            $size = $this->file->getSize();
+
+            $this->file->storeAs('', $stored, ['disk' => ClientDownload::DISK]);
+
+            // Hashed from the STORED bytes, not the temporary upload: it is the
+            // stored copy an operator will compare against what rdgen built.
+            $disk = Storage::disk(ClientDownload::DISK);
+            $sha256 = hash_file('sha256', $disk->path($stored)) ?: null;
+
+            $download->fill([
+                'filename' => $stored,
+                'original_name' => $original,
+                'size' => $size,
+                'sha256' => $sha256,
+            ]);
+        }
+
+        $download->fill([
+            'label' => trim($this->label),
+            'platform' => $this->platform,
+            'arch' => trim($this->arch) !== '' ? trim($this->arch) : null,
+            'version' => trim($this->version) !== '' ? trim($this->version) : null,
+            'notes' => trim($this->notes) !== '' ? trim($this->notes) : null,
+            'is_published' => $this->isPublished,
+        ]);
+
+        if (! $this->editing) {
+            $download->uploaded_by = auth()->id();
+            $download->sort_order = (int) ClientDownload::max('sort_order') + 1;
+        }
+
+        $download->save();
+
+        if ($previous && $previous !== $download->filename) {
+            Storage::disk(ClientDownload::DISK)->delete($previous);
+        }
+
+        ConsoleAudit::record(
+            $this->editing ? 'client_download.update' : 'client_download.create',
+            ($this->editing ? 'Updated' : 'Uploaded').' client download '.$download->label
+                .' ('.$download->original_name.')',
+            'client_download',
+            (string) $download->id,
+        );
+
+        $this->closeModal();
+    }
+
+    public function togglePublished(int $id): void
+    {
+        $this->authorizeConsole('setting', 'rw');
+
+        $download = ClientDownload::findOrFail($id);
+        $download->is_published = ! $download->is_published;
+        $download->save();
+
+        ConsoleAudit::record(
+            'client_download.'.($download->is_published ? 'publish' : 'unpublish'),
+            ($download->is_published ? 'Published' : 'Unpublished').' client download '.$download->label,
+            'client_download',
+            (string) $download->id,
+        );
+    }
+
+    public function move(int $id, string $direction): void
+    {
+        $this->authorizeConsole('setting', 'rw');
+
+        $ordered = ClientDownload::ordered()->get()->values();
+        $index = $ordered->search(fn (ClientDownload $d) => $d->id === $id);
+
+        if ($index === false) {
+            return;
+        }
+
+        $target = $direction === 'up' ? $index - 1 : $index + 1;
+
+        if ($target < 0 || $target >= $ordered->count()) {
+            return;
+        }
+
+        // Rewrite the whole column: sort_order starts life as an append
+        // counter, so neighbouring rows can share a value and a bare swap
+        // would be a no-op.
+        $reordered = $ordered->all();
+        [$reordered[$index], $reordered[$target]] = [$reordered[$target], $reordered[$index]];
+
+        foreach ($reordered as $position => $download) {
+            $download->update(['sort_order' => $position + 1]);
+        }
+    }
+
+    public function deleteDownload(int $id): void
+    {
+        $this->authorizeConsole('setting', 'rw');
+
+        $download = ClientDownload::findOrFail($id);
+        $label = $download->label;
+        $download->delete(); // the model's deleting hook removes the file
+
+        ConsoleAudit::record(
+            'client_download.delete',
+            'Deleted client download '.$label,
+            'client_download',
+            (string) $id,
+        );
+    }
+
+    public function closeModal(): void
+    {
+        $this->showModal = false;
+        $this->resetForm();
+    }
+
+    private function resetForm(): void
+    {
+        $this->reset('editing', 'file', 'label', 'arch', 'version', 'notes',
+            'touchedLabel', 'touchedPlatform');
+        $this->platform = 'unknown';
+        $this->isPublished = true;
+        $this->resetValidation();
+    }
+
+    /**
+     * Basename to store the bytes under. Never the uploaded name: it decides a
+     * path on disk, and the original is kept in its own column for the
+     * Content-Disposition filename.
+     */
+    private function storedName(string $original): string
+    {
+        $extension = ClientPlatform::extension($original);
+        $base = Str::slug(pathinfo($original, PATHINFO_FILENAME)) ?: 'client';
+
+        return Str::limit($base, 80, '').'-'.Str::random(8).($extension ? '.'.$extension : '');
+    }
+
+    /**
+     * Upload ceiling in KB. Kept below PHP's post_max_size on purpose: past it
+     * the request is dropped before Laravel sees it, and the operator gets an
+     * empty page instead of a validation message.
+     */
+    public static function maxKilobytes(): int
+    {
+        return max(1024, (int) config('cortendesk.downloads_max_kb', 30720));
+    }
+
+    public function render()
+    {
+        return view('livewire.client-download-manager', [
+            'downloads' => ClientDownload::ordered()->with('uploader')->get(),
+            'platformOptions' => ClientPlatform::options(),
+            'maxKb' => self::maxKilobytes(),
+            'canManage' => $this->consoleAllows('setting', 'rw'),
+        ]);
+    }
+}

--- a/app/Livewire/SettingsPage.php
+++ b/app/Livewire/SettingsPage.php
@@ -33,6 +33,9 @@ class SettingsPage extends Component
 
     public string $rdgenUrl = '';
 
+    /** Whether the sign-in page shows the published client-download icons. */
+    public bool $downloadsOnLogin = true;
+
     public int $logRetentionDays = 365;
 
     public bool $requireDeviceApproval = false;
@@ -135,6 +138,7 @@ class SettingsPage extends Component
         $this->publicKey = Setting::get('public_key', config('cortendesk.public_key')) ?? '';
         $this->onlineWindow = (int) (Setting::get('online_window', (string) config('cortendesk.online_window')) ?: 60);
         $this->rdgenUrl = Setting::get('rdgen_url', config('cortendesk.rdgen_url')) ?? '';
+        $this->downloadsOnLogin = Setting::get('downloads_on_login', config('cortendesk.downloads_on_login') ? '1' : '0') === '1';
         $this->logRetentionDays = (int) (Setting::get('log_retention_days', (string) config('cortendesk.log_retention_days')) ?: 0);
         $this->requireDeviceApproval = (bool) Setting::get('require_device_approval', '0');
         $this->twoFactorRequired = Setting::get('two_factor_required', '0') === '1';
@@ -206,7 +210,7 @@ class SettingsPage extends Component
             str_starts_with($root, 'smtp') => 'email',
             $root === 'logRetentionDays' => 'maintenance',
             in_array($root, ['twoFactorRequired', 'twoFactorRequiredAdmins', 'emailLoginVerification', 'emailTrustedDeviceDays'], true) => 'security',
-            in_array($root, ['idServer', 'relayServer', 'publicKey', 'onlineWindow', 'rdgenUrl', 'relayServers', 'requireDeviceApproval'], true) => 'server',
+            in_array($root, ['idServer', 'relayServer', 'publicKey', 'onlineWindow', 'rdgenUrl', 'downloadsOnLogin', 'relayServers', 'requireDeviceApproval'], true) => 'server',
             default => null,
         };
     }
@@ -290,6 +294,7 @@ class SettingsPage extends Component
         Setting::put('public_key', trim($this->publicKey));
         Setting::put('online_window', (string) $this->onlineWindow);
         Setting::put('rdgen_url', rtrim($this->rdgenUrl, '/'));
+        Setting::put('downloads_on_login', $this->downloadsOnLogin ? '1' : '0');
         Setting::put('log_retention_days', (string) $this->logRetentionDays);
         Setting::put('require_device_approval', $this->requireDeviceApproval ? '1' : '0');
         Setting::put('two_factor_required', $this->twoFactorRequired ? '1' : '0');

--- a/app/Models/ClientDownload.php
+++ b/app/Models/ClientDownload.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace App\Models;
+
+use App\Support\ClientPlatform;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Facades\Storage;
+
+/**
+ * A custom RustDesk client build offered for download.
+ *
+ * The bytes live on the private `downloads` disk and are only ever streamed by
+ * ClientDownloadController, so nothing here — and nothing in a view — should
+ * build a URL from `filename`.
+ */
+#[Fillable([
+    'label', 'platform', 'arch', 'version', 'notes',
+    'filename', 'original_name', 'size', 'sha256',
+    'is_published', 'sort_order', 'uploaded_by',
+])]
+class ClientDownload extends Model
+{
+    /** The disk the uploaded bytes live on (rooted in /data in Docker). */
+    public const DISK = 'downloads';
+
+    protected function casts(): array
+    {
+        return [
+            'is_published' => 'boolean',
+            'size' => 'integer',
+            'sort_order' => 'integer',
+            'download_count' => 'integer',
+        ];
+    }
+
+    /**
+     * Deleting a row deletes its bytes. Registered as a model event rather
+     * than done in the component so a future console command or tinker session
+     * cannot leave orphaned files behind in the volume.
+     */
+    protected static function booted(): void
+    {
+        static::deleting(function (self $download) {
+            Storage::disk(self::DISK)->delete($download->filename);
+        });
+    }
+
+    public function uploader(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'uploaded_by');
+    }
+
+    /** Rows the public download page may show. */
+    public function scopePublished(Builder $query): Builder
+    {
+        return $query->where('is_published', true);
+    }
+
+    /**
+     * Operator order first, then platform, then newest — so an install that
+     * never touches sort_order still gets a stable, sensible list.
+     */
+    public function scopeOrdered(Builder $query): Builder
+    {
+        return $query->orderBy('sort_order')->orderBy('platform')->orderByDesc('id');
+    }
+
+    public function platformLabel(): string
+    {
+        return ClientPlatform::label($this->platform);
+    }
+
+    public function archLabel(): string
+    {
+        return ClientPlatform::archLabel($this->arch);
+    }
+
+    /** "24.6 MB" — the size the download link advertises. */
+    public function humanSize(): string
+    {
+        $bytes = (int) $this->size;
+
+        if ($bytes < 1024) {
+            return $bytes.' B';
+        }
+
+        $units = ['KB', 'MB', 'GB'];
+        $value = $bytes / 1024;
+
+        foreach ($units as $i => $unit) {
+            if ($value < 1024 || $i === count($units) - 1) {
+                return round($value, $value < 10 ? 1 : 0).' '.$unit;
+            }
+
+            $value /= 1024;
+        }
+
+        return $bytes.' B';
+    }
+
+    /** Whether the bytes are actually still on disk (a recreated volume is not). */
+    public function fileExists(): bool
+    {
+        return Storage::disk(self::DISK)->exists($this->filename);
+    }
+}

--- a/app/Support/ClientPlatform.php
+++ b/app/Support/ClientPlatform.php
@@ -1,0 +1,183 @@
+<?php
+
+namespace App\Support;
+
+/**
+ * Filename -> platform/architecture guessing for uploaded client builds.
+ *
+ * rdgen names its output after the build it just ran
+ * (`rustdesk-1.4.0-x86_64.exe`, `rustdesk-1.4.0-aarch64.apk`, …), so the
+ * uploader can fill the form in for the operator. Every guess is only a
+ * default: ClientDownloadManager offers a dropdown that wins over whatever is
+ * returned here, because a renamed file must not be able to mislabel itself.
+ *
+ * The extension allowlist is also the upload validator, so anything added here
+ * becomes accepted input — keep it to installer formats.
+ */
+class ClientPlatform
+{
+    /** Platform slugs, in the order the public page lists them. */
+    public const PLATFORMS = ['windows', 'macos', 'linux', 'android', 'ios', 'unknown'];
+
+    /** Extension => platform. Lower-cased before lookup. */
+    private const BY_EXTENSION = [
+        'exe' => 'windows',
+        'msi' => 'windows',
+        'msix' => 'windows',
+        'dmg' => 'macos',
+        'pkg' => 'macos',
+        'deb' => 'linux',
+        'rpm' => 'linux',
+        'appimage' => 'linux',
+        'flatpak' => 'linux',
+        'apk' => 'android',
+        'aab' => 'android',
+        'ipa' => 'ios',
+        // Ambiguous containers: allowed (rdgen ships portable Windows and
+        // Linux builds this way) but never platform evidence on their own —
+        // the keyword pass below or the operator decides.
+        'zip' => 'unknown',
+        'gz' => 'unknown',
+        'xz' => 'unknown',
+        'tgz' => 'unknown',
+    ];
+
+    /**
+     * Substrings that identify a platform when the extension cannot. Ordered:
+     * 'macos' before 'mac', and 'windows'/'win' before anything shorter, so a
+     * longer name never matches on a fragment of another.
+     */
+    private const BY_KEYWORD = [
+        'windows' => 'windows',
+        'win64' => 'windows',
+        'win32' => 'windows',
+        'macos' => 'macos',
+        'darwin' => 'macos',
+        'osx' => 'macos',
+        'android' => 'android',
+        'linux' => 'linux',
+        'ubuntu' => 'linux',
+        'debian' => 'linux',
+        'fedora' => 'linux',
+        'ios' => 'ios',
+        'iphone' => 'ios',
+    ];
+
+    /** Architecture tokens, longest/most specific first. */
+    private const BY_ARCH = [
+        'aarch64' => 'arm64',
+        'arm64' => 'arm64',
+        'armv7' => 'armv7',
+        'armeabi' => 'armv7',
+        'x86_64' => 'x86_64',
+        'amd64' => 'x86_64',
+        'x64' => 'x86_64',
+        'i686' => 'x86',
+        'i386' => 'x86',
+        'x86' => 'x86',
+        'universal' => 'universal',
+    ];
+
+    /** @return array<int,string> extensions accepted by the uploader */
+    public static function allowedExtensions(): array
+    {
+        return array_keys(self::BY_EXTENSION);
+    }
+
+    /** Lower-cased extension of a filename, '' when it has none. */
+    public static function extension(string $filename): string
+    {
+        return strtolower(pathinfo($filename, PATHINFO_EXTENSION));
+    }
+
+    public static function extensionAllowed(string $filename): bool
+    {
+        return array_key_exists(self::extension($filename), self::BY_EXTENSION);
+    }
+
+    /**
+     * Best guess at the platform of an uploaded build. Extension first (it is
+     * the only part of a filename that has to be true for the file to install
+     * at all), then a keyword pass for the ambiguous containers.
+     */
+    public static function fromFilename(string $filename): string
+    {
+        $name = strtolower(basename($filename));
+
+        $platform = self::BY_EXTENSION[self::extension($name)] ?? 'unknown';
+
+        if ($platform !== 'unknown') {
+            return $platform;
+        }
+
+        foreach (self::BY_KEYWORD as $needle => $guess) {
+            if (str_contains($name, $needle)) {
+                return $guess;
+            }
+        }
+
+        return 'unknown';
+    }
+
+    /** Best guess at the architecture, or null when the name says nothing. */
+    public static function archFromFilename(string $filename): ?string
+    {
+        $name = strtolower(basename($filename));
+
+        foreach (self::BY_ARCH as $needle => $arch) {
+            if (str_contains($name, $needle)) {
+                return $arch;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * A human label for the file, used as the default "Label" in the uploader:
+     * "Windows (64-bit)", "Android (ARM64)", …
+     */
+    public static function labelFromFilename(string $filename): string
+    {
+        $platform = self::label(self::fromFilename($filename));
+        $arch = self::archLabel(self::archFromFilename($filename));
+
+        return $arch === '' ? $platform : $platform.' ('.$arch.')';
+    }
+
+    public static function label(string $platform): string
+    {
+        return match ($platform) {
+            'windows' => 'Windows',
+            'macos' => 'macOS',
+            'linux' => 'Linux',
+            'android' => 'Android',
+            'ios' => 'iOS',
+            default => 'Other',
+        };
+    }
+
+    public static function archLabel(?string $arch): string
+    {
+        return match ($arch) {
+            'arm64' => 'ARM64',
+            'armv7' => 'ARMv7',
+            'x86_64' => '64-bit',
+            'x86' => '32-bit',
+            'universal' => 'Universal',
+            default => '',
+        };
+    }
+
+    /** @return array<string,string> slug => label, for a <select> */
+    public static function options(): array
+    {
+        $options = [];
+
+        foreach (self::PLATFORMS as $platform) {
+            $options[$platform] = self::label($platform);
+        }
+
+        return $options;
+    }
+}

--- a/config/cortendesk.php
+++ b/config/cortendesk.php
@@ -83,6 +83,26 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Client Downloads
+    |--------------------------------------------------------------------------
+    | Installers uploaded under System -> Client Downloads and offered on the
+    | public /downloads page.
+    |
+    | downloads_max_kb must stay BELOW PHP's post_max_size (docker/php.ini,
+    | 32M) and nginx's client_max_body_size (docker/nginx.conf.template, 32m).
+    | Past those the request dies before Laravel sees it and the operator gets a
+    | broken page instead of a validation error, so the three are raised
+    | together or not at all.
+    |
+    | downloads_on_login controls only the icon row under the sign-in form; the
+    | /downloads page itself is always reachable (unpublish the builds to empty
+    | it).
+    */
+    'downloads_max_kb' => env('CORTENDESK_DOWNLOADS_MAX_KB', 30720),
+    'downloads_on_login' => filter_var(env('CORTENDESK_DOWNLOADS_ON_LOGIN', true), FILTER_VALIDATE_BOOL),
+
+    /*
+    |--------------------------------------------------------------------------
     | OIDC break-glass switch
     |--------------------------------------------------------------------------
     | Set CORTENDESK_OIDC_DISABLED=true to turn single sign-on off from the

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -47,6 +47,23 @@ return [
             'report' => false,
         ],
 
+        /*
+         * Uploaded client installers (System -> Client Downloads).
+         *
+         * Private, and rooted OUTSIDE storage/ by default in Docker: the image
+         * mounts nothing at /app/storage, so anything written there is lost the
+         * next time the container is recreated. docker/entrypoint.sh points
+         * this at /data/downloads, inside the volume that already holds the
+         * database and the server key pair. Files are streamed by
+         * ClientDownloadController, so no public symlink is involved.
+         */
+        'downloads' => [
+            'driver' => 'local',
+            'root' => env('CORTENDESK_DOWNLOADS_PATH', storage_path('app/downloads')),
+            'throw' => false,
+            'report' => false,
+        ],
+
         's3' => [
             'driver' => 's3',
             'key' => env('AWS_ACCESS_KEY_ID'),

--- a/config/livewire.php
+++ b/config/livewire.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+|--------------------------------------------------------------------------
+| Livewire — temporary file uploads only
+|--------------------------------------------------------------------------
+|
+| Deliberately a partial config: Livewire merges this over its own defaults
+| (mergeConfigFrom), so every key it does not mention keeps whatever the
+| installed version ships. Publishing the whole file would freeze defaults we
+| have no opinion about and would have to be re-reconciled on every upgrade.
+|
+| The one thing we do have an opinion about is the upload ceiling. Livewire
+| validates the temporary upload itself, BEFORE a component's own rules ever
+| run, and its default is 12 MB — under which a 26 MB custom RustDesk client
+| fails at the Livewire endpoint with a redirect and no message on screen. So
+| the temp-upload limit tracks the same setting the Client Downloads screen
+| validates against.
+|
+| The full chain, smallest last, all four must allow the file:
+|
+|   nginx  client_max_body_size  32m    (docker/nginx.conf.template)
+|   PHP    post_max_size         32M    (docker/php.ini)
+|   PHP    upload_max_filesize   32M    (docker/php.ini)
+|   Livewire temporary_file_upload.rules  <- here
+|   CortenDesk cortendesk.downloads_max_kb  (config/cortendesk.php, 30 MB)
+|
+| Raise the two php.ini values and the nginx one together before raising
+| CORTENDESK_DOWNLOADS_MAX_KB: past nginx or PHP the request is rejected before
+| Laravel sees it, and the operator gets a broken page instead of a validation
+| error.
+*/
+
+return [
+
+    'temporary_file_upload' => [
+        'disk' => env('LIVEWIRE_TEMPORARY_FILE_UPLOAD_DISK'),
+        // Deliberately 1 MB looser than cortendesk.downloads_max_kb: a file
+        // just over the limit then reaches the component, and the operator gets
+        // CortenDesk's own message naming the limit instead of Livewire's
+        // silent 422 at the upload endpoint.
+        'rules' => ['required', 'file', 'max:'.((int) env('CORTENDESK_DOWNLOADS_MAX_KB', 30720) + 1024)],
+        'directory' => null,
+        'middleware' => null,
+        'preview_mimes' => [
+            'png', 'gif', 'bmp', 'svg', 'wav', 'mp4',
+            'mov', 'avi', 'wmv', 'mp3', 'm4a',
+            'jpg', 'jpeg', 'mpga', 'webp', 'wma',
+        ],
+        // An installer is tens of MB over whatever the operator's uplink is;
+        // 5 minutes is not always enough.
+        'max_upload_time' => 15,
+        'cleanup' => true,
+    ],
+
+];

--- a/database/migrations/2026_08_17_000010_create_client_downloads_table.php
+++ b/database/migrations/2026_08_17_000010_create_client_downloads_table.php
@@ -1,0 +1,55 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Custom RustDesk client builds offered for download.
+ *
+ * One row per uploaded installer. The bytes live on the `downloads` disk (see
+ * config/filesystems.php) and are always served through
+ * ClientDownloadController, never as a static path — so `filename` is a
+ * generated basename this table owns and `original_name` is only ever used as
+ * the name suggested to the browser.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('client_downloads', function (Blueprint $table) {
+            $table->id();
+            $table->string('label');
+            // windows|macos|linux|android|ios|unknown — auto-detected from the
+            // uploaded filename, overridable in the uploader. Indexed because
+            // the public page groups by it.
+            $table->string('platform', 32)->index();
+            $table->string('arch', 32)->nullable();
+            $table->string('version', 64)->nullable();
+            $table->string('notes', 500)->nullable();
+            // Basename on the downloads disk. Generated, never taken from the
+            // upload; unique so a row can never be pointed at another's bytes.
+            $table->string('filename')->unique();
+            $table->string('original_name');
+            $table->unsignedBigInteger('size')->default(0);
+            // sha256 of the stored bytes, so an operator can verify a build
+            // matches what rdgen produced.
+            $table->string('sha256', 64)->nullable();
+            // Unpublished rows stay in the console but disappear from the
+            // public page — the way to stage a build, or retire one without
+            // deleting the bytes.
+            $table->boolean('is_published')->default(true)->index();
+            $table->integer('sort_order')->default(0);
+            $table->unsignedBigInteger('download_count')->default(0);
+            // Kept for the audit trail; nullable so deleting the uploader
+            // never takes their uploads with them.
+            $table->foreignId('uploaded_by')->nullable()->constrained('users')->nullOnDelete();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('client_downloads');
+    }
+};

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -86,6 +86,14 @@ else
     echo "[cortendesk] embedded ID server and relay are off (CORTENDESK_EMBEDDED_SERVER)"
 fi
 
+# --- uploaded client installers ----------------------------------------------
+# System -> Client Downloads writes here. Default it into the /data volume:
+# nothing is mounted at /app/storage, so a default under storage/ would silently
+# lose every uploaded build the next time the container is recreated.
+export CORTENDESK_DOWNLOADS_PATH="${CORTENDESK_DOWNLOADS_PATH:-/data/downloads}"
+mkdir -p "$CORTENDESK_DOWNLOADS_PATH"
+chown www-data:www-data "$CORTENDESK_DOWNLOADS_PATH"
+
 # --- APP_KEY: use the env if provided, else generate once into /data --------
 if [ -z "${APP_KEY:-}" ]; then
     if [ ! -f /data/.app_key ]; then

--- a/public/assets/css/cortendesk.css
+++ b/public/assets/css/cortendesk.css
@@ -193,6 +193,7 @@ html[data-sidenav-size="condensed"]:not([data-layout=topnav]) .rd-sidebar-versio
     17. TABS + CHIPS      .nav-bordered, .rd-chiprow, .rd-scrollbox, master/detail
     18. AUTH              the signed-out card
     19. PHONE             the 390px contract — wrap guards, tap targets, modals
+    20. DOWNLOAD TILES    .rd-dl — the client-installer links (auth + /downloads)
 
    Naming: anything new is prefixed `rd-` so it is obvious what is ours and
    what came from the theme.
@@ -2912,4 +2913,97 @@ html[data-sidenav-size="sm-hover"]:not([data-layout="topnav"]) .wrapper .leftsid
 .rd-selcol {
     width: 28px;
     padding-right: 0 !important;
+}
+
+/* =========================================================================
+   20. DOWNLOAD TILES
+   .rd-dl — the published client installers, rendered by
+   resources/views/components/client-download-links.blade.php on the sign-in
+   page, the public /downloads page and the console preview card.
+
+   One tile per build: platform icon, label, size, download glyph. Rows rather
+   than a grid, because the label carries the useful part ("Windows (64-bit)")
+   and an icon-only grid would need a tooltip to be usable. Sized to sit inside
+   the 320px-wide auth card without wrapping.
+   ========================================================================= */
+.rd-dl {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.rd-dl-tile {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 10px 12px;
+    border: 1px solid var(--rd-border-strong);
+    border-radius: var(--rd-radius-sm);
+    background: var(--rd-surface-2);
+    color: var(--rd-ink);
+    text-decoration: none;
+    transition: background-color .15s ease, border-color .15s ease;
+    /* A phone tap target, and the reason the tile is a row: 44px of height is
+       cheap vertically and impossible in an icon grid. */
+    min-height: 44px;
+}
+
+.rd-dl-tile:hover,
+.rd-dl-tile:focus-visible {
+    background: var(--rd-surface-3);
+    border-color: rgba(var(--rd-accent-rgb), 0.45);
+    color: var(--rd-ink);
+}
+
+.rd-dl-icon {
+    flex: 0 0 auto;
+    line-height: 1;
+}
+
+/* min-width:0 so a long label truncates instead of widening the auth card. */
+.rd-dl-text {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+    flex: 1 1 auto;
+}
+
+.rd-dl-label {
+    font-size: .875rem;
+    font-weight: 500;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.rd-dl-meta {
+    font-size: .75rem;
+    color: var(--rd-ink-muted);
+}
+
+.rd-dl-arrow {
+    flex: 0 0 auto;
+    color: var(--rd-ink-dim);
+    font-size: 1rem;
+}
+
+.rd-dl-tile:hover .rd-dl-arrow {
+    color: var(--rd-accent-ink);
+}
+
+/* Compact: the sign-in row and the console preview, where the tiles are a
+   secondary offer under the real content. */
+.rd-dl-compact .rd-dl-tile {
+    padding: 8px 10px;
+    gap: 10px;
+}
+
+/* Platform heading on the public page. */
+.rd-dl-group {
+    margin: 0 0 6px;
+    font-size: .75rem;
+    font-weight: 600;
+    letter-spacing: .04em;
+    text-transform: uppercase;
+    color: var(--rd-ink-muted);
 }

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -97,6 +97,35 @@
                 </div>
             </form>
             @endunless
+
+            {{-- Custom client installers, under the sign-in prompts: the machine
+                 in front of the technician usually needs the client before
+                 anyone needs the console. Hidden when nothing is published, or
+                 when the operator turns the row off in Settings -> Server.
+                 The full list is always at /downloads. --}}
+            @php
+                $showDownloads = \App\Models\Setting::get(
+                    'downloads_on_login',
+                    config('cortendesk.downloads_on_login') ? '1' : '0'
+                ) === '1';
+                $loginDownloads = $showDownloads
+                    ? \App\Models\ClientDownload::published()->ordered()->get()
+                    : collect();
+            @endphp
+
+            @if ($loginDownloads->isNotEmpty())
+                <div class="rd-auth-or mt-4">
+                    <hr class="flex-grow-1 my-0">
+                    <span>get the client</span>
+                    <hr class="flex-grow-1 my-0">
+                </div>
+
+                <x-client-download-links :downloads="$loginDownloads" compact />
+
+                <div class="text-center mt-2">
+                    <a href="{{ route('downloads.index') }}" class="rd-auth-quiet">All downloads</a>
+                </div>
+            @endif
         </div>
     </div>
 @endsection

--- a/resources/views/client-downloads/index.blade.php
+++ b/resources/views/client-downloads/index.blade.php
@@ -1,0 +1,8 @@
+@extends('layouts.app')
+
+@section('title', 'Client Downloads')
+@section('subtitle', 'System')
+
+@section('content')
+    @livewire(App\Livewire\ClientDownloadManager::class)
+@endsection

--- a/resources/views/components/client-download-links.blade.php
+++ b/resources/views/components/client-download-links.blade.php
@@ -1,0 +1,26 @@
+@props(['downloads' => null, 'compact' => false])
+
+@php
+    // Loaded here when no collection is passed in, so a caller (the sign-in
+    // page) stays a single line and needs no controller change. Same shape as
+    // the sidebar reading rdgen_url out of Setting.
+    $downloads = $downloads ?? \App\Models\ClientDownload::published()->ordered()->get();
+@endphp
+
+@if ($downloads->isNotEmpty())
+    <div {{ $attributes->merge(['class' => 'rd-dl' . ($compact ? ' rd-dl-compact' : '')]) }}>
+        @foreach ($downloads as $download)
+            <a class="rd-dl-tile" href="{{ route('downloads.show', $download) }}"
+               title="{{ $download->label }}{{ $download->version ? ' · ' . $download->version : '' }} · {{ $download->humanSize() }}">
+                <x-platform-icon :platform="$download->platform" size="{{ $compact ? 'fs-22' : 'fs-24' }}" class="rd-dl-icon" />
+                <span class="rd-dl-text">
+                    <span class="rd-dl-label">{{ $download->label }}</span>
+                    <span class="rd-dl-meta">
+                        {{ $download->humanSize() }}@if ($download->version) · {{ $download->version }}@endif
+                    </span>
+                </span>
+                <i class="ri-download-2-line rd-dl-arrow"></i>
+            </a>
+        @endforeach
+    </div>
+@endif

--- a/resources/views/downloads/index.blade.php
+++ b/resources/views/downloads/index.blade.php
@@ -1,0 +1,50 @@
+@extends('layouts.guest')
+
+@section('title', 'Client Downloads')
+
+@section('content')
+    <div class="card">
+
+        <div class="card-header rd-auth-head py-3 text-center d-flex align-items-center justify-content-center">
+            <a href="{{ url('/') }}" class="auth-brand mb-0">
+                <img src="{{ \App\Support\Asset::url('assets/images/cortendesk-sm.svg') }}" alt="CortenDesk" width="60" height="60" class="auth-brand-logo">
+                <span class="auth-brand-wordmark">Corten<span>Desk</span></span>
+            </a>
+        </div>
+
+        <div class="card-body p-4">
+
+            <div class="text-center mb-4">
+                <h4 class="rd-auth-title">Client Downloads</h4>
+                <p class="rd-auth-sub">
+                    Installers for this server, pre-configured to connect on first run.
+                </p>
+            </div>
+
+            @if ($downloads->isEmpty())
+                <div class="rd-empty">
+                    <div class="rd-empty-icon"><i class="ri-download-cloud-line"></i></div>
+                    <p class="rd-empty-title">No client builds published yet.</p>
+                    <p class="rd-empty-text">An administrator uploads them under System &rarr; Client Downloads.</p>
+                </div>
+            @else
+                @foreach ($downloads->groupBy('platform') as $platform => $group)
+                    <p class="rd-dl-group">
+                        <x-platform-icon :platform="$platform" size="fs-16" class="me-1" />
+                        {{ \App\Support\ClientPlatform::label($platform) }}
+                    </p>
+                    <x-client-download-links :downloads="$group" class="mb-3" />
+                @endforeach
+
+                <p class="rd-auth-note mb-0 text-center">
+                    Only download these from a link you trust. Check with whoever supports your machines
+                    if you were not expecting this page.
+                </p>
+            @endif
+
+            <div class="text-center mt-3">
+                <a href="{{ route('login') }}" class="rd-auth-quiet">Console sign-in</a>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/layouts/partials/sidebar.blade.php
+++ b/resources/views/layouts/partials/sidebar.blade.php
@@ -164,6 +164,13 @@
                     </a>
                 </li>
 
+                <li class="side-nav-item {{ request()->routeIs('client-downloads') ? 'menuitem-active' : '' }}">
+                    <a href="{{ route('client-downloads') }}" class="side-nav-link {{ request()->routeIs('client-downloads') ? 'active' : '' }}">
+                        <i class="ri-download-cloud-line"></i>
+                        <span> Client Downloads </span>
+                    </a>
+                </li>
+
                 @php
                     $rdgenUrl = \App\Models\Setting::get('rdgen_url', config('cortendesk.rdgen_url'));
                 @endphp

--- a/resources/views/livewire/client-download-manager.blade.php
+++ b/resources/views/livewire/client-download-manager.blade.php
@@ -1,0 +1,262 @@
+<div>
+    <div class="card">
+
+        {{-- Toolbar --}}
+        <div class="rd-toolbar">
+            <div>
+                <h4 class="header-title">Client Downloads</h4>
+                <p class="rd-card-sub mb-0">
+                    Installers you built with <strong>Build Installers</strong>, published on the sign-in page and at
+                    <a href="{{ route('downloads.index') }}" target="_blank" rel="noopener">{{ route('downloads.index') }}</a>
+                    — a link anyone can open, no console account needed.
+                </p>
+            </div>
+            <div class="rd-toolbar-actions">
+                <button type="button" class="btn btn-primary" wire:click="create" @disabled(! $canManage)>
+                    <i class="ri-upload-2-line"></i>Upload Build
+                </button>
+            </div>
+        </div>
+
+        {{-- Desktop table (md and up) --}}
+        <div class="table-responsive d-none d-md-block">
+            <table class="table table-hover table-centered mb-0">
+                <thead>
+                <tr>
+                    <th style="width: 42px;">OS</th>
+                    <th>Label</th>
+                    <th>File</th>
+                    <th>Size</th>
+                    <th>Version</th>
+                    <th>Downloads</th>
+                    <th>Status</th>
+                    <th class="text-end">Action</th>
+                </tr>
+                </thead>
+                <tbody>
+                @forelse ($downloads as $download)
+                    <tr wire:key="cd-{{ $download->id }}">
+                        <td><x-platform-icon :platform="$download->platform" /></td>
+                        <td class="fw-semibold">
+                            {{ $download->label }}
+                            @if ($download->notes)
+                                <span class="d-block rd-card-sub">{{ $download->notes }}</span>
+                            @endif
+                        </td>
+                        <td>
+                            <span class="rd-mono fs-13">{{ $download->original_name }}</span>
+                            @unless ($download->fileExists())
+                                {{-- The bytes live in the /data volume; a row without them
+                                     means the volume was replaced, not that the row is wrong. --}}
+                                <span class="badge bg-danger-subtle text-danger ms-1" title="The stored file is missing from the downloads volume. Re-upload it.">file missing</span>
+                            @endunless
+                        </td>
+                        <td>{{ $download->humanSize() }}</td>
+                        <td>{{ $download->version ?: '—' }}</td>
+                        <td><span class="badge bg-secondary-subtle text-secondary">{{ $download->download_count }}</span></td>
+                        <td>
+                            @if ($download->is_published)
+                                <span class="badge bg-success-subtle text-success">Published</span>
+                            @else
+                                <span class="badge bg-secondary-subtle text-secondary">Hidden</span>
+                            @endif
+                        </td>
+                        <td class="text-end rd-rowact">
+                            <a href="javascript:void(0);" class="rd-iconbtn me-1" title="Move up"
+                               wire:click="move({{ $download->id }}, 'up')"><i class="ri-arrow-up-line"></i></a>
+                            <a href="javascript:void(0);" class="rd-iconbtn me-2" title="Move down"
+                               wire:click="move({{ $download->id }}, 'down')"><i class="ri-arrow-down-line"></i></a>
+                            <a href="javascript:void(0);" class="rd-act me-2"
+                               wire:click="togglePublished({{ $download->id }})">{{ $download->is_published ? 'Hide' : 'Publish' }}</a>
+                            <a href="javascript:void(0);" class="rd-act me-2" wire:click="edit({{ $download->id }})">Edit</a>
+                            <a href="javascript:void(0);" class="text-danger"
+                               wire:click="deleteDownload({{ $download->id }})"
+                               wire:confirm="Delete this build? The uploaded file is removed too and any link to it stops working.">Delete</a>
+                        </td>
+                    </tr>
+                @empty
+                    <tr>
+                        <td colspan="8" class="rd-empty-cell">
+                            <div class="rd-empty">
+                                <div class="rd-empty-icon"><i class="ri-download-cloud-line"></i></div>
+                                <p class="rd-empty-title">No client builds uploaded yet.</p>
+                                <p class="rd-empty-text">
+                                    Build an installer with <strong>Build Installers</strong>, then upload it here.
+                                    CortenDesk reads the platform off the filename and shows the matching icon on the
+                                    sign-in page.
+                                </p>
+                                <button type="button" class="btn btn-sm btn-outline-light" wire:click="create" @disabled(! $canManage)>Upload Build</button>
+                            </div>
+                        </td>
+                    </tr>
+                @endforelse
+                </tbody>
+            </table>
+        </div>
+
+        {{-- Mobile card list (below md) --}}
+        <div class="d-md-none rd-cardlist">
+            @forelse ($downloads as $download)
+                <div class="rd-mini" wire:key="mcd-{{ $download->id }}">
+                    <div class="rd-mini-head">
+                        <div class="min-width-0">
+                            <span class="rd-mini-title">
+                                <x-platform-icon :platform="$download->platform" size="fs-16" class="me-1" />{{ $download->label }}
+                            </span>
+                            <span class="rd-mini-sub">{{ $download->original_name }}</span>
+                        </div>
+                        @if ($download->is_published)
+                            <span class="badge bg-success-subtle text-success">Published</span>
+                        @else
+                            <span class="badge bg-secondary-subtle text-secondary">Hidden</span>
+                        @endif
+                    </div>
+                    <div class="rd-mini-foot">
+                        <span class="rd-mini-sub">
+                            {{ $download->humanSize() }}@if ($download->version) · {{ $download->version }}@endif ·
+                            {{ $download->download_count }} downloads
+                        </span>
+                        <div class="rd-mini-acts">
+                            <a href="javascript:void(0);" class="rd-iconbtn" title="{{ $download->is_published ? 'Hide' : 'Publish' }}"
+                               wire:click="togglePublished({{ $download->id }})"><i class="{{ $download->is_published ? 'ri-eye-off-line' : 'ri-eye-line' }}"></i></a>
+                            <a href="javascript:void(0);" class="rd-iconbtn" title="Edit"
+                               wire:click="edit({{ $download->id }})"><i class="ri-pencil-line"></i></a>
+                            <a href="javascript:void(0);" class="rd-iconbtn text-danger" title="Delete"
+                               wire:click="deleteDownload({{ $download->id }})"
+                               wire:confirm="Delete this build? The uploaded file is removed too and any link to it stops working."><i class="ri-delete-bin-line"></i></a>
+                        </div>
+                    </div>
+                </div>
+            @empty
+                <div class="rd-empty">
+                    <div class="rd-empty-icon"><i class="ri-download-cloud-line"></i></div>
+                    <p class="rd-empty-title">No client builds uploaded yet.</p>
+                    <button type="button" class="btn btn-sm btn-outline-light" wire:click="create" @disabled(! $canManage)>Upload Build</button>
+                </div>
+            @endforelse
+        </div>
+    </div>
+
+    {{-- Preview of what the sign-in page shows, so publishing is not a guess --}}
+    @if ($downloads->where('is_published', true)->isNotEmpty())
+        <div class="card">
+            <div class="card-header">
+                <h5 class="card-title mb-0">Sign-in page preview</h5>
+            </div>
+            <div class="card-body">
+                <x-client-download-links :downloads="$downloads->where('is_published', true)->values()" compact />
+            </div>
+        </div>
+    @endif
+
+    {{-- Upload / edit modal (plain Bootstrap markup, toggled by Livewire) --}}
+    @if ($showModal)
+        <div class="modal fade show d-block" tabindex="-1" role="dialog" aria-modal="true">
+            <div class="modal-dialog modal-dialog-centered modal-dialog-scrollable">
+                <div class="modal-content">
+                    <form wire:submit="save">
+                        <div class="modal-header">
+                            <h5 class="modal-title">{{ $editing ? 'Edit Build' : 'Upload Build' }}</h5>
+                            <button type="button" class="btn-close" wire:click="closeModal" aria-label="Close"></button>
+                        </div>
+                        <div class="modal-body">
+
+                            <div class="mb-3">
+                                <label class="form-label" for="cd-file">
+                                    Installer {!! $editing ? '' : '<span class="text-danger">*</span>' !!}
+                                </label>
+                                <input type="file" id="cd-file" class="form-control @error('file') is-invalid @enderror"
+                                       wire:model="file">
+                                @error('file') <div class="invalid-feedback">{{ $message }}</div> @enderror
+                                <div class="form-text">
+                                    {{ $editing ? 'Pick a file only to replace the one already stored. ' : '' }}
+                                    Up to {{ round($maxKb / 1024) }} MB. The platform below is filled in from the
+                                    filename — change it if the guess is wrong.
+                                </div>
+                                <div wire:loading wire:target="file" class="form-text">Uploading…</div>
+                                {{-- Livewire validates the temporary upload at its own endpoint,
+                                     before the component sees it. A rejection there (or a 413 from
+                                     nginx) never re-renders anything, so without this the operator
+                                     picks a too-large file and watches nothing happen. --}}
+                                <div class="invalid-feedback d-block" style="display: none;" data-cd-upload-error>
+                                    That file was rejected before it finished uploading — almost always
+                                    because it is bigger than the {{ round($maxKb / 1024) }} MB limit.
+                                </div>
+                            </div>
+
+                            <div class="mb-3">
+                                <label class="form-label" for="cd-label">Label <span class="text-danger">*</span></label>
+                                <input type="text" id="cd-label" class="form-control @error('label') is-invalid @enderror"
+                                       wire:model="label" autocomplete="off" placeholder="e.g. Windows (64-bit)">
+                                @error('label') <div class="invalid-feedback">{{ $message }}</div> @enderror
+                            </div>
+
+                            <div class="row">
+                                <div class="col-sm-6 mb-3">
+                                    <label class="form-label" for="cd-platform">Platform icon</label>
+                                    <select id="cd-platform" class="form-select @error('platform') is-invalid @enderror"
+                                            wire:model="platform">
+                                        @foreach ($platformOptions as $value => $text)
+                                            <option value="{{ $value }}">{{ $text }}</option>
+                                        @endforeach
+                                    </select>
+                                    @error('platform') <div class="invalid-feedback">{{ $message }}</div> @enderror
+                                </div>
+                                <div class="col-sm-6 mb-3">
+                                    <label class="form-label" for="cd-version">Version</label>
+                                    <input type="text" id="cd-version" class="form-control @error('version') is-invalid @enderror"
+                                           wire:model="version" placeholder="e.g. 1.4.0">
+                                    @error('version') <div class="invalid-feedback">{{ $message }}</div> @enderror
+                                </div>
+                            </div>
+
+                            <div class="mb-3">
+                                <label class="form-label" for="cd-notes">Note</label>
+                                <textarea id="cd-notes" rows="2" class="form-control @error('notes') is-invalid @enderror"
+                                          wire:model="notes" placeholder="Shown under the label in the console only."></textarea>
+                                @error('notes') <div class="invalid-feedback">{{ $message }}</div> @enderror
+                            </div>
+
+                            <div class="mb-0">
+                                <div class="form-check form-switch">
+                                    <input class="form-check-input" type="checkbox" role="switch" id="cd-published"
+                                           wire:model="isPublished">
+                                    <label class="form-check-label" for="cd-published">Published</label>
+                                </div>
+                                <div class="form-text">
+                                    Published builds are downloadable by <strong>anyone</strong> with the link — that is
+                                    what makes them useful on a machine with no console account. Leave this off to stage
+                                    a build first.
+                                </div>
+                            </div>
+                        </div>
+                        <div class="modal-footer">
+                            <button type="button" class="btn btn-light" wire:click="closeModal">Cancel</button>
+                            <button type="submit" class="btn btn-primary" wire:target="file" wire:loading.attr="disabled">
+                                <span wire:loading.remove wire:target="save">{{ $editing ? 'Save Changes' : 'Upload' }}</span>
+                                <span wire:loading wire:target="save">Saving…</span>
+                            </button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+        <div class="modal-backdrop fade show"></div>
+    @endif
+
+    @script
+    <script>
+        // Registered once per component, on document, so it still fires for the
+        // modal markup Livewire adds and removes on each open/close.
+        const cdUploadError = (show) => {
+            const box = document.querySelector('[data-cd-upload-error]');
+            if (box) {
+                box.style.display = show ? 'block' : 'none';
+            }
+        };
+
+        document.addEventListener('livewire-upload-start', () => cdUploadError(false));
+        document.addEventListener('livewire-upload-error', () => cdUploadError(true));
+    </script>
+    @endscript
+</div>

--- a/resources/views/livewire/settings-page.blade.php
+++ b/resources/views/livewire/settings-page.blade.php
@@ -102,6 +102,14 @@
                                     <div class="form-text">Opened by the sidebar's <strong>Build Installers</strong> entry — point it at your own rdgen instance. Leave empty to hide the menu entry.</div>
                                 </div>
                                 <div class="mb-3">
+                                    <div class="form-check form-switch">
+                                        <input class="form-check-input" type="checkbox" role="switch" id="downloadsOnLogin"
+                                               wire:model="downloadsOnLogin">
+                                        <label class="form-check-label" for="downloadsOnLogin">Show client downloads on the sign-in page</label>
+                                    </div>
+                                    <div class="form-text">Lists the builds published under <a href="{{ route('client-downloads') }}">Client Downloads</a> beneath the sign-in form. The <a href="{{ route('downloads.index') }}" target="_blank" rel="noopener">/downloads</a> page stays reachable either way — unpublish a build to withdraw it.</div>
+                                </div>
+                                <div class="mb-3">
                                     <label class="form-label">Online window (seconds)</label>
                                     <input type="number" class="form-control @error('onlineWindow') is-invalid @enderror"
                                            wire:model="onlineWindow" min="20" max="600" style="max-width: 140px;">

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,6 +3,7 @@
 use App\Http\Controllers\Api\ClientOidcController;
 use App\Http\Controllers\Api\WebClientController;
 use App\Http\Controllers\AuthController;
+use App\Http\Controllers\ClientDownloadController;
 use App\Http\Controllers\DashboardController;
 use App\Http\Controllers\InvitationController;
 use App\Http\Controllers\OidcController;
@@ -64,6 +65,17 @@ Route::get('/login/oidc/client-callback',
     [ClientOidcController::class, 'browserCallback'])
     ->name('login.oidc.client-callback');
 
+// Custom client installers. Outside both guest and auth groups on purpose: the
+// page is meant to be linked to somebody who has no console account, and a
+// technician at a fresh machine may already be signed in on their own laptop —
+// neither case should be redirected. Only published rows are visible, the
+// controller streams the bytes as an attachment, and the throttle bounds a
+// scraper (the files are the expensive part, not the page).
+Route::middleware('throttle:60,1')->group(function () {
+    Route::get('/downloads', [ClientDownloadController::class, 'index'])->name('downloads.index');
+    Route::get('/downloads/{download}', [ClientDownloadController::class, 'show'])->name('downloads.show');
+});
+
 Route::middleware('auth')->group(function () {
     Route::post('/logout', [AuthController::class, 'logout'])->name('logout');
 
@@ -104,6 +116,12 @@ Route::middleware('auth')->group(function () {
     Route::view('/users', 'users.index')->name('users')
         ->middleware('console-can:user,r');
     Route::view('/settings', 'settings.index')->name('settings')
+        ->middleware('console-can:setting,r');
+
+    // Uploading the installers the public /downloads page hands out. Gated by
+    // the `setting` area rather than an area of its own — see the
+    // ClientDownloadManager docblock for why.
+    Route::view('/client-downloads', 'client-downloads.index')->name('client-downloads')
         ->middleware('console-can:setting,r');
 
     // Login history and the console audit trail are the sensitive half of the


### PR DESCRIPTION
Closes #43.

An operator who builds custom clients (Build Installers / rdgen) has nowhere to put the output. The console links to the builder but not to the builds, so the installers end up on a file share, in an email, or on a USB stick — and the person who needs one is usually standing at a machine that has no console account and no client yet.

This adds the missing half:

- **System → Client Downloads** uploads a build, reads the platform off the filename (`rustdesk-1.4.0-aarch64.apk` → Android/ARM64) and shows the matching `<x-platform-icon>`. The guess is only ever a default: a dropdown overrides it, because a renamed file must not be able to mislabel itself. Publish/hide, reorder, replace the file, delete — every mutation audited.
- The published builds appear as **icon tiles under the sign-in form** (switchable off in Settings → Server) and on a **public `/downloads` page** an operator can send to anybody.

### Design notes, in case they read as odd later

- Both public routes sit outside the `guest` and `auth` groups, like `login.oidc.client-callback`: the page is meant for someone with no account, and a technician who happens to be signed in on that browser must not be redirected either. Only `is_published` rows are visible or fetchable, the row is found by primary key so no request ever names a path, the bytes are streamed as an attachment with `nosniff`, and both routes are throttled.
- Permissions reuse the `setting` area rather than adding one. The area list is a fixed matrix (`Permissions::CONSOLE_RESOURCES`, mirrored by `Role` and the API-token grid), and "may publish a file the whole internet can fetch" is the same trust level as "may edit the server settings".
- Uploads go to a new private `downloads` disk, which `docker/entrypoint.sh` defaults to `/data/downloads`. Nothing is mounted at `/app/storage`, so a default under `storage/` would lose every build the next time the container is recreated (I lost mine twice before landing on this). The controller streams the files, so no public symlink is involved.
- `config/livewire.php` is a deliberately partial config (Livewire merges it over its own defaults). Livewire validates the temporary upload at its own endpoint before a component sees it, and its default ceiling is 12 MB — under which a 26 MB Android build fails with nothing on screen. The temp-upload rule now tracks `CORTENDESK_DOWNLOADS_MAX_KB`, one MB looser, so the message the operator meets is CortenDesk's own, naming the limit.
- The whole chain has to allow the file: nginx `client_max_body_size 32m`, PHP `upload_max_filesize`/`post_max_size` 32M, the Livewire rule, then `cortendesk.downloads_max_kb` (30 MB). **The shipped limits are untouched** — raising the app limit alone would only move the failure to a layer with no error message, so the two `php.ini` values and the nginx one have to go first. Worth knowing: a universal APK will not fit under 32M as shipped.

### Testing

Verified end to end against a throwaway 1.6.0 container built from this branch: a 26 MB APK uploads, auto-detects as Android/ARM64, appears on `/downloads` and under the sign-in form, and downloads back byte-identical as an attachment; a 31 MB file is refused by the validator with the limit named; a 40 MB file (past PHP) trips the upload-error hint rather than failing silently; hide/publish, reorder and delete behave, with the file removed from the volume and each mutation in the console audit trail; a non-admin without the `setting` area is bounced exactly like `/settings`.

It is also now running on my own install, <https://rust.gneill.net> — the tiles under the sign-in prompts and the `/downloads` page are my real custom-built clients (Windows .exe, Windows .msi, Android ARMv7), so you can click through it before reading a line of the diff. Happy to screen-share the console side (upload, auto-detect, publish/hide, audit entries) if you'd rather see the admin half working than take my word for it.

Full disclosure on process: I described what I wanted to my AI partner and got this on the first try — so please review it as you would any outside patch rather than assuming I hand-checked every line. I have read it, I understand the design choices above, and I am running it in production, but you know this codebase and I don't.

Happy to split it into smaller commits, drop the sign-in-page half, or rework any of the choices above if you'd rather take it differently.

George
