### PR TITLE
Add bulk device group movement

### DIFF
--- a/app/Livewire/DeviceList.php
+++ b/app/Livewire/DeviceList.php
@@ -98,6 +98,11 @@ class DeviceList extends Component
     /** One-line outcome of the last bulk action ("Added 4, 2 already there"). */
     public string $bulkResult = '';
 
+    /** "Move to Group" picker (issue #47). -1 means no target selected; 0 means no group. */
+    public bool $groupPickerOpen = false;
+
+    public int $moveGroupId = -1;
+
     #[Url(except: '')]
     public string $search = '';
 
@@ -306,6 +311,7 @@ class DeviceList extends Component
         $this->selected = [];
         $this->bulkResult = '';
         $this->abPickerOpen = false;
+        $this->groupPickerOpen = false;
     }
 
     /** Header checkbox: select every row on the current page. */
@@ -341,6 +347,71 @@ class DeviceList extends Component
         $count = $devices->count();
         $this->clearSelection();
         $this->bulkResult = $count.' '.Str::plural('device', $count).' moved to the recycle bin.';
+    }
+
+    public function openGroupPicker(): void
+    {
+        $this->authorizeConsole('device', 'rw');
+
+        if ($this->selected === []) {
+            return;
+        }
+
+        $this->moveGroupId = -1;
+        $this->groupPickerOpen = true;
+    }
+
+    public function closeGroupPicker(): void
+    {
+        $this->groupPickerOpen = false;
+    }
+
+    /** Move the selected, still-visible devices to an accessible group or no group. */
+    public function moveSelectedToGroup(): void
+    {
+        $this->authorizeConsole('device', 'rw');
+
+        if ($this->moveGroupId < 0) {
+            $this->addError('moveGroupId', 'Pick a device group.');
+
+            return;
+        }
+
+        $group = $this->moveGroupId === 0
+            ? null
+            : $this->accessibleDeviceGroups()->firstWhere('id', $this->moveGroupId);
+        if ($this->moveGroupId > 0 && ! $group) {
+            $this->addError('moveGroupId', 'Pick an accessible device group.');
+
+            return;
+        }
+
+        $targetId = $group?->id;
+        $targetName = $group?->name ?? 'No group';
+        $moved = 0;
+        $unchanged = 0;
+
+        foreach ($this->selectedDevices() as $device) {
+            if ((int) $device->device_group_id === (int) $targetId) {
+                $unchanged++;
+
+                continue;
+            }
+
+            $device->update(['device_group_id' => $targetId]);
+            $moved++;
+        }
+
+        ConsoleAudit::record(
+            'device.group-move',
+            'Moved '.$moved.' '.Str::plural('device', $moved).' to '.$targetName.'; '.$unchanged.' unchanged.',
+            'device-group',
+            $targetId === null ? null : (string) $targetId,
+        );
+
+        $this->clearSelection();
+        $this->bulkResult = 'Moved '.$moved.' '.Str::plural('device', $moved).' to '.$targetName.'. '
+            .$unchanged.' unchanged.';
     }
 
     public function openAbPicker(): void
@@ -619,9 +690,7 @@ class DeviceList extends Component
                 && ($key !== 'owner' || $user->is_admin);
         }
 
-        $groups = $user->seesAllDevices()
-            ? DeviceGroup::orderBy('name')->get()
-            : DeviceGroup::whereIn('id', $user->accessibleDeviceGroupIds())->orderBy('name')->get();
+        $groups = $this->accessibleDeviceGroups();
 
         return view('livewire.device-list', [
             'devices' => $devices,
@@ -638,6 +707,16 @@ class DeviceList extends Component
             'trashedCount' => Device::visibleTo($user)->onlyTrashed()->count(),
             'pendingCount' => $pendingCount,
         ]);
+    }
+
+    /** Device groups this actor may see and therefore may choose as move targets. */
+    private function accessibleDeviceGroups()
+    {
+        $user = auth()->user();
+
+        return DeviceGroup::orderBy('name')
+            ->when(! $user->seesAllDevices(), fn ($q) => $q->whereIn('id', $user->accessibleDeviceGroupIds() ?: [0]))
+            ->get();
     }
 
     /**

--- a/app/Livewire/DeviceList.php
+++ b/app/Livewire/DeviceList.php
@@ -334,6 +334,18 @@ class DeviceList extends Component
             ->get();
     }
 
+    /** Selected devices are constrained to the current rendered page. */
+    private function selectedDevicesOnCurrentPage()
+    {
+        $selectedIds = array_values(array_unique(array_filter(array_map('intval', $this->selected))));
+
+        return $this->filteredQuery(auth()->user())
+            ->paginate($this->perPage)
+            ->getCollection()
+            ->whereIn('id', $selectedIds)
+            ->values();
+    }
+
     public function bulkDelete(): void
     {
         $this->authorizeConsole('device', 'rw');
@@ -371,6 +383,10 @@ class DeviceList extends Component
     {
         $this->authorizeConsole('device', 'rw');
 
+        if ($this->selected === []) {
+            return;
+        }
+
         if ($this->moveGroupId < 0) {
             $this->addError('moveGroupId', 'Pick a device group.');
 
@@ -386,12 +402,19 @@ class DeviceList extends Component
             return;
         }
 
+        $devices = $this->selectedDevicesOnCurrentPage();
+        if ($devices->isEmpty()) {
+            $this->clearSelection();
+
+            return;
+        }
+
         $targetId = $group?->id;
         $targetName = $group?->name ?? 'No group';
         $moved = 0;
         $unchanged = 0;
 
-        foreach ($this->selectedDevices() as $device) {
+        foreach ($devices as $device) {
             if ((int) $device->device_group_id === (int) $targetId) {
                 $unchanged++;
 

--- a/app/Livewire/DeviceList.php
+++ b/app/Livewire/DeviceList.php
@@ -425,12 +425,14 @@ class DeviceList extends Component
             $moved++;
         }
 
-        ConsoleAudit::record(
-            'device.group-move',
-            'Moved '.$moved.' '.Str::plural('device', $moved).' to '.$targetName.'; '.$unchanged.' unchanged.',
-            'device-group',
-            $targetId === null ? null : (string) $targetId,
-        );
+        if ($moved > 0) {
+            ConsoleAudit::record(
+                'device.group-move',
+                'Moved '.$moved.' '.Str::plural('device', $moved).' to '.$targetName.'; '.$unchanged.' unchanged.',
+                'device-group',
+                $targetId === null ? null : (string) $targetId,
+            );
+        }
 
         $this->clearSelection();
         $this->bulkResult = 'Moved '.$moved.' '.Str::plural('device', $moved).' to '.$targetName.'. '

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true">
+    <testsuites>
+        <testsuite name="Feature">
+            <directory>tests/Feature</directory>
+        </testsuite>
+    </testsuites>
+    <php>
+        <env name="APP_ENV" value="testing"/>
+        <env name="APP_KEY" value="base64:8ybhhQ3VCn1imtruwM8ywzK1KIh9H9HYQdSIy8dozNQ="/>
+        <env name="BCRYPT_ROUNDS" value="4"/>
+        <env name="CACHE_STORE" value="array"/>
+        <env name="DB_CONNECTION" value="sqlite"/>
+        <env name="DB_DATABASE" value=":memory:"/>
+        <env name="MAIL_MAILER" value="array"/>
+        <env name="QUEUE_CONNECTION" value="sync"/>
+        <env name="SESSION_DRIVER" value="array"/>
+    </php>
+</phpunit>

--- a/resources/views/livewire/device-list.blade.php
+++ b/resources/views/livewire/device-list.blade.php
@@ -151,15 +151,18 @@
             </div>
         @endunless
 
-        {{-- Bulk actions bar (issue #15) — appears when rows are selected. --}}
+        {{-- Bulk actions bar (issue #15, #47) — appears when rows are selected. --}}
         @if (! $trashed && ($selected !== [] || $bulkResult !== ''))
-            <div class="rd-toolbar d-none d-md-flex">
+            <div class="rd-toolbar d-flex flex-wrap gap-2 align-items-center">
                 @if ($selected !== [])
                     <span class="fs-13 fw-semibold">{{ count($selected) }} selected</span>
                     <button type="button" class="btn btn-sm btn-light" wire:click="openAbPicker">
                         <i class="ri-contacts-book-2-line me-1"></i>Add to Address Book…
                     </button>
                     @if (auth()->user()?->consoleAllows('device', 'rw'))
+                        <button type="button" class="btn btn-sm btn-light" wire:click="openGroupPicker">
+                            <i class="ri-folder-transfer-line me-1"></i>Move to Group…
+                        </button>
                         <button type="button" class="btn btn-sm btn-outline-danger" wire:click="bulkDelete"
                                 wire:confirm="Move {{ count($selected) }} selected device(s) to the recycle bin?">
                             <i class="ri-delete-bin-line me-1"></i>Delete
@@ -367,6 +370,10 @@
                                 <span class="rd-mini-sub text-truncate">{{ $device->alias ?: $device->hostname }}</span>
                             </div>
                         </div>
+                        @unless ($trashed)
+                            <input type="checkbox" class="form-check-input flex-shrink-0" value="{{ $device->id }}"
+                                   wire:model.live="selected" aria-label="Select device {{ $device->rustdesk_id }}">
+                        @endunless
                         @if ($trashed)
                             <span class="badge bg-warning-subtle text-warning flex-shrink-0">Deleted</span>
                         @elseif ($device->isOnline())
@@ -434,6 +441,38 @@
             {{ $devices->links() }}
         </div>
     </div>
+
+    {{-- "Move to Group" picker (issue #47) --}}
+    @if ($groupPickerOpen)
+        <div class="modal fade show d-block" tabindex="-1" style="background: rgba(0,0,0,.6);" wire:keydown.escape="closeGroupPicker">
+            <div class="modal-dialog modal-dialog-centered">
+                <div class="modal-content">
+                    <form wire:submit="moveSelectedToGroup">
+                        <div class="modal-header">
+                            <h5 class="modal-title">Move {{ count($selected) }} {{ Str::plural('device', count($selected)) }} to a group</h5>
+                            <button type="button" class="btn-close" wire:click="closeGroupPicker"></button>
+                        </div>
+                        <div class="modal-body">
+                            <label class="form-label">Device group</label>
+                            <select class="form-select @error('moveGroupId') is-invalid @enderror" wire:model="moveGroupId">
+                                <option value="-1">Choose…</option>
+                                <option value="0">No group</option>
+                                @foreach ($groups as $group)
+                                    <option value="{{ $group->id }}">{{ $group->name }}</option>
+                                @endforeach
+                            </select>
+                            @error('moveGroupId') <div class="invalid-feedback">{{ $message }}</div> @enderror
+                            <div class="form-text">Only device groups you can access are listed.</div>
+                        </div>
+                        <div class="modal-footer">
+                            <button type="button" class="btn btn-light" wire:click="closeGroupPicker">Cancel</button>
+                            <button type="submit" class="btn btn-primary">Move</button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    @endif
 
     {{-- "Add to Address Book" picker (issue #15) --}}
     @if ($abPickerOpen)

--- a/resources/views/livewire/device-list.blade.php
+++ b/resources/views/livewire/device-list.blade.php
@@ -444,17 +444,17 @@
 
     {{-- "Move to Group" picker (issue #47) --}}
     @if ($groupPickerOpen)
-        <div class="modal fade show d-block" tabindex="-1" style="background: rgba(0,0,0,.6);" wire:keydown.escape="closeGroupPicker">
+        <div class="modal fade show d-block" tabindex="-1" role="dialog" aria-modal="true" aria-labelledby="move-group-title" style="background: rgba(0,0,0,.6);" wire:keydown.escape="closeGroupPicker">
             <div class="modal-dialog modal-dialog-centered">
                 <div class="modal-content">
                     <form wire:submit="moveSelectedToGroup">
                         <div class="modal-header">
-                            <h5 class="modal-title">Move {{ count($selected) }} {{ Str::plural('device', count($selected)) }} to a group</h5>
-                            <button type="button" class="btn-close" wire:click="closeGroupPicker"></button>
+                            <h5 id="move-group-title" class="modal-title">Move {{ count($selected) }} {{ Str::plural('device', count($selected)) }} to a group</h5>
+                            <button type="button" class="btn-close" aria-label="Close move to group dialog" wire:click="closeGroupPicker"></button>
                         </div>
                         <div class="modal-body">
-                            <label class="form-label">Device group</label>
-                            <select class="form-select @error('moveGroupId') is-invalid @enderror" wire:model="moveGroupId">
+                            <label class="form-label" for="move-group-id">Device group</label>
+                            <select id="move-group-id" class="form-select @error('moveGroupId') is-invalid @enderror" wire:model="moveGroupId">
                                 <option value="-1">Choose…</option>
                                 <option value="0">No group</option>
                                 @foreach ($groups as $group)

--- a/tests/Feature/BulkDeviceGroupMoveTest.php
+++ b/tests/Feature/BulkDeviceGroupMoveTest.php
@@ -172,6 +172,82 @@ test('a device manager bulk move with an empty selection does nothing', function
         ->and(ConsoleAudit::count())->toBe(0);
 });
 
+test('the move to group picker renders accessible dialog and form semantics', function () {
+    $manager = User::factory()->create();
+    $group = DeviceGroup::create(['name' => 'Accessible target']);
+    $manager->deviceGroups()->attach($group->id);
+    $device = Device::create([
+        'rustdesk_id' => 'accessibility',
+        'uuid' => 'accessible-picker',
+        'status' => Device::STATUS_ACTIVE,
+        'device_group_id' => $group->id,
+    ]);
+
+    $this->actingAs($manager);
+
+    Livewire::test(DeviceList::class)
+        ->set('selected', [(string) $device->id])
+        ->call('openGroupPicker')
+        ->assertSeeHtml('role="dialog"')
+        ->assertSeeHtml('aria-modal="true"')
+        ->assertSeeHtml('aria-labelledby="move-group-title"')
+        ->assertSeeHtml('id="move-group-title"')
+        ->assertSeeHtml('aria-label="Close move to group dialog"')
+        ->assertSeeHtml('for="move-group-id"')
+        ->assertSeeHtml('id="move-group-id"');
+});
+
+test('a forged inaccessible group target is rejected without mutation or audit', function () {
+    $manager = User::factory()->create();
+    $source = DeviceGroup::create(['name' => 'Source']);
+    $inaccessibleTarget = DeviceGroup::create(['name' => 'Inaccessible target']);
+    $manager->deviceGroups()->attach($source->id);
+    $device = Device::create([
+        'rustdesk_id' => 'forged-target',
+        'uuid' => 'forged-target',
+        'status' => Device::STATUS_ACTIVE,
+        'device_group_id' => $source->id,
+    ]);
+
+    $this->actingAs($manager);
+
+    Livewire::test(DeviceList::class)
+        ->set('selected', [(string) $device->id])
+        ->set('moveGroupId', $inaccessibleTarget->id)
+        ->call('moveSelectedToGroup')
+        ->assertHasErrors(['moveGroupId' => 'Pick an accessible device group.'])
+        ->assertSet('selected', [(string) $device->id])
+        ->assertSet('bulkResult', '');
+
+    expect($device->fresh()->device_group_id)->toBe($source->id)
+        ->and(ConsoleAudit::count())->toBe(0);
+});
+
+test('a missing move target is rejected without mutation or audit', function () {
+    $manager = User::factory()->create();
+    $source = DeviceGroup::create(['name' => 'Source']);
+    $manager->deviceGroups()->attach($source->id);
+    $device = Device::create([
+        'rustdesk_id' => 'missing-target',
+        'uuid' => 'missing-target',
+        'status' => Device::STATUS_ACTIVE,
+        'device_group_id' => $source->id,
+    ]);
+
+    $this->actingAs($manager);
+
+    Livewire::test(DeviceList::class)
+        ->set('selected', [(string) $device->id])
+        ->set('moveGroupId', -1)
+        ->call('moveSelectedToGroup')
+        ->assertHasErrors(['moveGroupId' => 'Pick a device group.'])
+        ->assertSet('selected', [(string) $device->id])
+        ->assertSet('bulkResult', '');
+
+    expect($device->fresh()->device_group_id)->toBe($source->id)
+        ->and(ConsoleAudit::count())->toBe(0);
+});
+
 test('a device manager can bulk remove visible selected devices from their group', function () {
     $manager = User::factory()->create();
     $source = DeviceGroup::create(['name' => 'Source']);

--- a/tests/Feature/BulkDeviceGroupMoveTest.php
+++ b/tests/Feature/BulkDeviceGroupMoveTest.php
@@ -56,6 +56,30 @@ test('a device manager bulk moves only visible selected devices and reports move
     expect(ConsoleAudit::count())->toBe(1);
 });
 
+test('a device manager reports an unchanged current-page group move without auditing it', function () {
+    $manager = User::factory()->create();
+    $target = DeviceGroup::create(['name' => 'Target']);
+    $manager->deviceGroups()->attach($target->id);
+    $device = Device::create([
+        'rustdesk_id' => '103',
+        'uuid' => 'already-in-target',
+        'status' => Device::STATUS_ACTIVE,
+        'device_group_id' => $target->id,
+    ]);
+
+    $this->actingAs($manager);
+
+    Livewire::test(DeviceList::class)
+        ->set('selected', [(string) $device->id])
+        ->set('moveGroupId', $target->id)
+        ->call('moveSelectedToGroup')
+        ->assertSet('selected', [])
+        ->assertSet('bulkResult', 'Moved 0 devices to Target. 1 unchanged.');
+
+    expect($device->fresh()->device_group_id)->toBe($target->id)
+        ->and(ConsoleAudit::count())->toBe(0);
+});
+
 test('a device manager cannot bulk move a selected device from another page', function () {
     $manager = User::factory()->create();
     $source = DeviceGroup::create(['name' => 'Source']);

--- a/tests/Feature/BulkDeviceGroupMoveTest.php
+++ b/tests/Feature/BulkDeviceGroupMoveTest.php
@@ -56,6 +56,98 @@ test('a device manager bulk moves only visible selected devices and reports move
     expect(ConsoleAudit::count())->toBe(1);
 });
 
+test('a device manager cannot bulk move a selected device from another page', function () {
+    $manager = User::factory()->create();
+    $source = DeviceGroup::create(['name' => 'Source']);
+    $target = DeviceGroup::create(['name' => 'Target']);
+    $manager->deviceGroups()->attach([$source->id, $target->id]);
+
+    $firstPage = Device::create([
+        'rustdesk_id' => '300',
+        'uuid' => 'first-page',
+        'status' => Device::STATUS_ACTIVE,
+        'device_group_id' => $source->id,
+    ]);
+    $currentPage = Device::create([
+        'rustdesk_id' => '301',
+        'uuid' => 'current-page',
+        'status' => Device::STATUS_ACTIVE,
+        'device_group_id' => $source->id,
+    ]);
+
+    $this->actingAs($manager);
+
+    Livewire::test(DeviceList::class)
+        ->set('perPage', 1)
+        ->call('gotoPage', 2)
+        ->set('selected', [(string) $firstPage->id, (string) $currentPage->id])
+        ->set('moveGroupId', $target->id)
+        ->call('moveSelectedToGroup')
+        ->assertSet('bulkResult', 'Moved 1 device to Target. 0 unchanged.');
+
+    expect($firstPage->fresh()->device_group_id)->toBe($source->id)
+        ->and($currentPage->fresh()->device_group_id)->toBe($target->id);
+});
+
+test('a device manager cannot bulk move a selected device excluded by the active filter', function () {
+    $manager = User::factory()->create();
+    $source = DeviceGroup::create(['name' => 'Source']);
+    $target = DeviceGroup::create(['name' => 'Target']);
+    $manager->deviceGroups()->attach([$source->id, $target->id]);
+
+    $matching = Device::create([
+        'rustdesk_id' => '400',
+        'uuid' => 'matching-filter',
+        'hostname' => 'included',
+        'status' => Device::STATUS_ACTIVE,
+        'device_group_id' => $source->id,
+    ]);
+    $excluded = Device::create([
+        'rustdesk_id' => '401',
+        'uuid' => 'excluded-filter',
+        'hostname' => 'excluded',
+        'status' => Device::STATUS_ACTIVE,
+        'device_group_id' => $source->id,
+    ]);
+
+    $this->actingAs($manager);
+
+    Livewire::test(DeviceList::class)
+        ->set('search', 'included')
+        ->set('selected', [(string) $excluded->id])
+        ->set('moveGroupId', $target->id)
+        ->call('moveSelectedToGroup')
+        ->assertSet('selected', [])
+        ->assertSet('bulkResult', '');
+
+    expect($matching->fresh()->device_group_id)->toBe($source->id)
+        ->and($excluded->fresh()->device_group_id)->toBe($source->id)
+        ->and(ConsoleAudit::count())->toBe(0);
+});
+
+test('a device manager bulk move with an empty selection does nothing', function () {
+    $manager = User::factory()->create();
+    $source = DeviceGroup::create(['name' => 'Source']);
+    $manager->deviceGroups()->attach($source->id);
+    $device = Device::create([
+        'rustdesk_id' => '500',
+        'uuid' => 'empty-selection',
+        'status' => Device::STATUS_ACTIVE,
+        'device_group_id' => $source->id,
+    ]);
+
+    $this->actingAs($manager);
+
+    Livewire::test(DeviceList::class)
+        ->call('moveSelectedToGroup')
+        ->assertHasNoErrors()
+        ->assertSet('selected', [])
+        ->assertSet('bulkResult', '');
+
+    expect($device->fresh()->device_group_id)->toBe($source->id)
+        ->and(ConsoleAudit::count())->toBe(0);
+});
+
 test('a device manager can bulk remove visible selected devices from their group', function () {
     $manager = User::factory()->create();
     $source = DeviceGroup::create(['name' => 'Source']);

--- a/tests/Feature/BulkDeviceGroupMoveTest.php
+++ b/tests/Feature/BulkDeviceGroupMoveTest.php
@@ -1,0 +1,79 @@
+<?php
+
+use App\Livewire\DeviceList;
+use App\Models\ConsoleAudit;
+use App\Models\Device;
+use App\Models\DeviceGroup;
+use App\Models\User;
+use Livewire\Livewire;
+
+test('a device manager bulk moves only visible selected devices and reports moved and unchanged counts', function () {
+    $manager = User::factory()->create();
+    $source = DeviceGroup::create(['name' => 'Source']);
+    $target = DeviceGroup::create(['name' => 'Target']);
+    $hiddenGroup = DeviceGroup::create(['name' => 'Hidden']);
+    $manager->deviceGroups()->attach([$source->id, $target->id]);
+
+    $moved = Device::create([
+        'rustdesk_id' => '100',
+        'uuid' => 'move',
+        'status' => Device::STATUS_ACTIVE,
+        'device_group_id' => $source->id,
+    ]);
+    $unchanged = Device::create([
+        'rustdesk_id' => '101',
+        'uuid' => 'same',
+        'status' => Device::STATUS_ACTIVE,
+        'device_group_id' => $target->id,
+    ]);
+    $hidden = Device::create([
+        'rustdesk_id' => '102',
+        'uuid' => 'hidden',
+        'status' => Device::STATUS_ACTIVE,
+        'device_group_id' => $hiddenGroup->id,
+    ]);
+
+    $this->actingAs($manager);
+
+    Livewire::test(DeviceList::class)
+        ->set('selected', [(string) $moved->id, (string) $unchanged->id, (string) $hidden->id])
+        ->set('moveGroupId', $target->id)
+        ->call('moveSelectedToGroup')
+        ->assertSet('selected', [])
+        ->assertSet('bulkResult', 'Moved 1 device to Target. 1 unchanged.');
+
+    expect($moved->fresh()->device_group_id)->toBe($target->id)
+        ->and($unchanged->fresh()->device_group_id)->toBe($target->id)
+        ->and($hidden->fresh()->device_group_id)->toBe($hiddenGroup->id);
+
+    $this->assertDatabaseHas('console_audits', [
+        'user_id' => $manager->id,
+        'action' => 'device.group-move',
+        'target_type' => 'device-group',
+        'target_id' => (string) $target->id,
+        'summary' => 'Moved 1 device to Target; 1 unchanged.',
+    ]);
+    expect(ConsoleAudit::count())->toBe(1);
+});
+
+test('a device manager can bulk remove visible selected devices from their group', function () {
+    $manager = User::factory()->create();
+    $source = DeviceGroup::create(['name' => 'Source']);
+    $manager->deviceGroups()->attach($source->id);
+    $device = Device::create([
+        'rustdesk_id' => '200',
+        'uuid' => 'remove-group',
+        'status' => Device::STATUS_ACTIVE,
+        'device_group_id' => $source->id,
+    ]);
+
+    $this->actingAs($manager);
+
+    Livewire::test(DeviceList::class)
+        ->set('selected', [(string) $device->id])
+        ->set('moveGroupId', 0)
+        ->call('moveSelectedToGroup')
+        ->assertSet('bulkResult', 'Moved 1 device to No group. 0 unchanged.');
+
+    expect($device->fresh()->device_group_id)->toBeNull();
+});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,0 +1,8 @@
+<?php
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+pest()->extend(TestCase::class)
+    ->use(RefreshDatabase::class)
+    ->in('Feature');

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Tests;
+
+use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
+
+abstract class TestCase extends BaseTestCase
+{
+    //
+}


### PR DESCRIPTION
## Summary

- add a responsive **Move to Group…** bulk action for selected devices
- constrain submitted selections to the authenticated user's current filtered paginator page
- support accessible device groups and **No group**, with moved/unchanged feedback
- emit one concise audit only when at least one device actually moves
- add mobile selection controls and an accessible group-picker dialog

## Security and behavior

- requires `device:rw` at both picker and mutation entry points
- re-checks device visibility and current page/filter scope server-side
- rejects forged, inaccessible, or missing group targets without mutation or audit
- preserves existing bulk delete and address-book behavior

## Verification

- `php artisan test` — **9 passed, 47 assertions**
- scoped Pint — passed
- Blade view cache — passed
- `git diff --check` — passed
- final independent spec and code-quality review — approved

Closes #47
