### PR TITLE
Add dependency-safe health endpoints

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,6 +75,6 @@ EXPOSE 8080 21115 21116 21116/udp 21117 21118 21119
 VOLUME /data
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=30s \
-    CMD wget -q -O /dev/null http://127.0.0.1:8080/login || exit 1
+    CMD wget -q -O /dev/null http://127.0.0.1:8080/health/ready || exit 1
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/app/Contracts/HealthProbeLimiter.php
+++ b/app/Contracts/HealthProbeLimiter.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Contracts;
+
+interface HealthProbeLimiter
+{
+    /**
+     * Returns true when the request is within its endpoint's limit.
+     */
+    public function allows(string $endpoint, string $identity, int $maximumAttempts): bool;
+}

--- a/app/Http/Controllers/HealthController.php
+++ b/app/Http/Controllers/HealthController.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Services\FleetDiagnostics;
+use Illuminate\Http\JsonResponse;
+
+class HealthController extends Controller
+{
+    public function live(): JsonResponse
+    {
+        return response()->json(['live' => true]);
+    }
+
+    public function ready(FleetDiagnostics $diagnostics): JsonResponse
+    {
+        $readiness = $diagnostics->readiness();
+
+        return response()->json($readiness, $readiness['ready'] ? 200 : 503);
+    }
+}

--- a/app/Http/Middleware/ThrottleHealthProbe.php
+++ b/app/Http/Middleware/ThrottleHealthProbe.php
@@ -15,7 +15,10 @@ class ThrottleHealthProbe
     {
         try {
             $maximumAttempts = (int) config('health.probe_limits.'.$endpoint, 1);
-            $allowed = app(HealthProbeLimiter::class)->allows($endpoint, (string) $request->ip(), $maximumAttempts);
+            // Health probes are public load-shedding endpoints. A single bucket
+            // per endpoint is intentional: forwarded client addresses are not a
+            // safe identity when private reverse proxies are broadly trusted.
+            $allowed = app(HealthProbeLimiter::class)->allows($endpoint, 'global', $maximumAttempts);
         } catch (Throwable) {
             $allowed = true;
         }
@@ -34,6 +37,7 @@ class ThrottleHealthProbe
                 ? ['live' => false]
                 : ['ready' => false, 'database' => false, 'id_server' => false, 'relay_server' => false],
             429,
+            ['Retry-After' => '60'],
         );
     }
 }

--- a/app/Http/Middleware/ThrottleHealthProbe.php
+++ b/app/Http/Middleware/ThrottleHealthProbe.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Contracts\HealthProbeLimiter;
+use Closure;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+class ThrottleHealthProbe
+{
+    public function handle(Request $request, Closure $next, string $endpoint): Response
+    {
+        try {
+            $maximumAttempts = (int) config('health.probe_limits.'.$endpoint, 1);
+            $allowed = app(HealthProbeLimiter::class)->allows($endpoint, (string) $request->ip(), $maximumAttempts);
+        } catch (Throwable) {
+            $allowed = true;
+        }
+
+        if (! $allowed) {
+            return $this->tooManyRequests($endpoint);
+        }
+
+        return $next($request);
+    }
+
+    private function tooManyRequests(string $endpoint): JsonResponse
+    {
+        return response()->json(
+            $endpoint === 'live'
+                ? ['live' => false]
+                : ['ready' => false, 'database' => false, 'id_server' => false, 'relay_server' => false],
+            429,
+        );
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,9 +2,11 @@
 
 namespace App\Providers;
 
+use App\Contracts\HealthProbeLimiter;
 use App\Contracts\TcpProbe;
 use App\Models\ApiToken;
 use App\Models\ClientToken;
+use App\Services\FileHealthProbeLimiter;
 use App\Services\SocketTcpProbe;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
@@ -18,6 +20,7 @@ class AppServiceProvider extends ServiceProvider
     public function register(): void
     {
         $this->app->bind(TcpProbe::class, SocketTcpProbe::class);
+        $this->app->bind(HealthProbeLimiter::class, FileHealthProbeLimiter::class);
     }
 
     /**

--- a/app/Services/FileHealthProbeLimiter.php
+++ b/app/Services/FileHealthProbeLimiter.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Services;
+
+use App\Contracts\HealthProbeLimiter;
+use Illuminate\Contracts\Cache\Factory as CacheFactory;
+use Throwable;
+
+class FileHealthProbeLimiter implements HealthProbeLimiter
+{
+    public function __construct(private CacheFactory $cache) {}
+
+    public function allows(string $endpoint, string $identity, int $maximumAttempts): bool
+    {
+        try {
+            // This deliberately names Laravel's local persistent file store rather
+            // than using the configured default, which may be database-backed.
+            $store = $this->cache->store('file');
+            $key = 'health-probe:'.hash('sha256', $endpoint.'|'.$identity);
+            $result = $store->lock($key.':lock', 1)->get(function () use ($store, $key, $maximumAttempts): array {
+                $attempts = (int) $store->get($key, 0) + 1;
+                // Use Repository::put so its DateTime TTL conversion preserves
+                // the one-minute expiry on Laravel's file store.
+                $store->put($key, $attempts, now()->addMinute());
+
+                return ['allowed' => $attempts <= max(1, $maximumAttempts)];
+            });
+
+            // A contended/unavailable local lock is not grounds for turning an
+            // outage report into a false negative.
+            return is_array($result) ? $result['allowed'] : true;
+        } catch (Throwable) {
+            // A probe must still report the outage it observes if its limiter's
+            // filesystem/cache backend is itself unavailable.
+            return true;
+        }
+    }
+}

--- a/app/Services/FileHealthProbeLimiter.php
+++ b/app/Services/FileHealthProbeLimiter.php
@@ -4,6 +4,7 @@ namespace App\Services;
 
 use App\Contracts\HealthProbeLimiter;
 use Illuminate\Contracts\Cache\Factory as CacheFactory;
+use Illuminate\Contracts\Cache\LockTimeoutException;
 use Throwable;
 
 class FileHealthProbeLimiter implements HealthProbeLimiter
@@ -17,7 +18,10 @@ class FileHealthProbeLimiter implements HealthProbeLimiter
             // than using the configured default, which may be database-backed.
             $store = $this->cache->store('file');
             $key = 'health-probe:'.hash('sha256', $endpoint.'|'.$identity);
-            $result = $store->lock($key.':lock', 1)->get(function () use ($store, $key, $maximumAttempts): array {
+            // File-store locks serialize the read/modify/write sequence. Wait at
+            // most one second: that covers the tiny critical section without
+            // making a health probe a long blocking request.
+            $result = $store->lock($key.':lock', 1)->block(1, function () use ($store, $key, $maximumAttempts): array {
                 $attempts = (int) $store->get($key, 0) + 1;
                 // Use Repository::put so its DateTime TTL conversion preserves
                 // the one-minute expiry on Laravel's file store.
@@ -26,9 +30,11 @@ class FileHealthProbeLimiter implements HealthProbeLimiter
                 return ['allowed' => $attempts <= max(1, $maximumAttempts)];
             });
 
-            // A contended/unavailable local lock is not grounds for turning an
-            // outage report into a false negative.
-            return is_array($result) ? $result['allowed'] : true;
+            return $result['allowed'];
+        } catch (LockTimeoutException) {
+            // Contention is not a limiter/backend failure. Reject rather than
+            // letting a contested request bypass the protective limit.
+            return false;
         } catch (Throwable) {
             // A probe must still report the outage it observes if its limiter's
             // filesystem/cache backend is itself unavailable.

--- a/app/Services/FleetDiagnostics.php
+++ b/app/Services/FleetDiagnostics.php
@@ -13,14 +13,23 @@ class FleetDiagnostics
 {
     public function __construct(private TcpProbe $tcp) {}
 
+    public function readiness(): array
+    {
+        $database = $this->databaseIsAvailable();
+        $idServer = $database && $this->configuredServerIsAvailable('id_server', 21116);
+        $relayServer = $database && $this->configuredServerIsAvailable('relay_server', 21117);
+
+        return [
+            'ready' => $database && $idServer && $relayServer,
+            'database' => $database,
+            'id_server' => $idServer,
+            'relay_server' => $relayServer,
+        ];
+    }
+
     public function report(): array
     {
-        $database = true;
-        try {
-            DB::select('select 1');
-        } catch (Throwable) {
-            $database = false;
-        }
+        $database = $this->databaseIsAvailable();
 
         $versions = Device::query()->approved()
             ->selectRaw("COALESCE(NULLIF(version, ''), 'unknown') as version, COUNT(*) as count")
@@ -105,6 +114,24 @@ class FleetDiagnostics
         }
 
         return $report;
+    }
+
+    private function databaseIsAvailable(): bool
+    {
+        try {
+            DB::select('select 1');
+
+            return true;
+        } catch (Throwable) {
+            return false;
+        }
+    }
+
+    private function configuredServerIsAvailable(string $key, int $defaultPort): bool
+    {
+        $server = $this->serverProbe($key, $defaultPort);
+
+        return ! $server['configured'] || $server['ok'];
     }
 
     private function serverProbe(string $key, int $defaultPort): array

--- a/app/Services/FleetDiagnostics.php
+++ b/app/Services/FleetDiagnostics.php
@@ -17,7 +17,7 @@ class FleetDiagnostics
     {
         $database = $this->databaseIsAvailable();
         $idServer = $database && $this->configuredServerIsAvailable('id_server', 21116);
-        $relayServer = $database && $this->configuredServerIsAvailable('relay_server', 21117);
+        $relayServer = $database && $this->relayPoolIsAvailable();
 
         return [
             'ready' => $database && $idServer && $relayServer,
@@ -132,6 +132,23 @@ class FleetDiagnostics
         $server = $this->serverProbe($key, $defaultPort);
 
         return ! $server['configured'] || $server['ok'];
+    }
+
+    /**
+     * Every configured relay in the active pool is required; an empty pool is
+     * intentionally not a readiness dependency.
+     */
+    private function relayPoolIsAvailable(): bool
+    {
+        foreach (Setting::relayServers() as $relay) {
+            [$host, $port] = $this->parseServer($relay['address'], 21117);
+
+            if ($host !== '' && ! $this->tcp->check($host, $port, 1.0)['ok']) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private function serverProbe(string $key, int $defaultPort): array

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -24,11 +24,13 @@ return Application::configure(basePath: dirname(__DIR__))
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
         then: function (): void {
-            // These public probes intentionally bypass the web middleware group:
-            // Liveness must remain process/request-only: a database-backed cache
-            // makes the normal throttle middleware a database dependency.
+            // These public probes intentionally bypass the web middleware group.
+            // A normal throttle can use a database-backed cache before either
+            // controller runs, masking an outage as a 500 instead of readiness's
+            // documented 503. Keep both paths dependency-free until readiness
+            // explicitly checks its dependencies.
             Route::get('/health/live', [HealthController::class, 'live']);
-            Route::get('/health/ready', [HealthController::class, 'ready'])->middleware('throttle:30,1');
+            Route::get('/health/ready', [HealthController::class, 'ready']);
         },
     )
     ->withMiddleware(function (Middleware $middleware): void {

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\HealthController;
 use App\Http\Middleware\ApiTokenCan;
 use App\Http\Middleware\ConsoleCan;
 use App\Http\Middleware\EnsureAdmin;
@@ -13,6 +14,7 @@ use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Route;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
@@ -20,6 +22,12 @@ return Application::configure(basePath: dirname(__DIR__))
         api: __DIR__.'/../routes/api.php',
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
+        then: function (): void {
+            // These public probes intentionally bypass the web middleware group:
+            // liveness must not require session or database access.
+            Route::get('/health/live', [HealthController::class, 'live'])->middleware('throttle:120,1');
+            Route::get('/health/ready', [HealthController::class, 'ready'])->middleware('throttle:30,1');
+        },
     )
     ->withMiddleware(function (Middleware $middleware): void {
         $middleware->alias([

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -8,6 +8,7 @@ use App\Http\Middleware\EnsureUserIsActive;
 use App\Http\Middleware\RequireEmailAddress;
 use App\Http\Middleware\RequireMailHealthy;
 use App\Http\Middleware\RequireTwoFactor;
+use App\Http\Middleware\ThrottleHealthProbe;
 use App\Http\Middleware\TrustConfiguredProxies;
 use App\Models\TrustedDevice;
 use Illuminate\Foundation\Application;
@@ -25,12 +26,10 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
         then: function (): void {
             // These public probes intentionally bypass the web middleware group.
-            // A normal throttle can use a database-backed cache before either
-            // controller runs, masking an outage as a 500 instead of readiness's
-            // documented 503. Keep both paths dependency-free until readiness
-            // explicitly checks its dependencies.
-            Route::get('/health/live', [HealthController::class, 'live']);
-            Route::get('/health/ready', [HealthController::class, 'ready']);
+            // Their dedicated limiter explicitly uses the persistent file cache,
+            // never the configured default store (which can be database-backed).
+            Route::get('/health/live', [HealthController::class, 'live'])->middleware('health-probe:live');
+            Route::get('/health/ready', [HealthController::class, 'ready'])->middleware('health-probe:ready');
         },
     )
     ->withMiddleware(function (Middleware $middleware): void {
@@ -40,6 +39,7 @@ return Application::configure(basePath: dirname(__DIR__))
             // Delegated console roles (PLAN D4). `admin` stays the super-admin
             // gate; `console-can` is the per-area one.
             'console-can' => ConsoleCan::class,
+            'health-probe' => ThrottleHealthProbe::class,
         ]);
         $middleware->appendToGroup('web', EnsureUserIsActive::class);
         // 2FA enrollment enforcement runs after the active-user check.

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -13,6 +13,7 @@ use App\Models\TrustedDevice;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
+use Illuminate\Http\Middleware\TrustProxies;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
@@ -24,8 +25,9 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
         then: function (): void {
             // These public probes intentionally bypass the web middleware group:
-            // liveness must not require session or database access.
-            Route::get('/health/live', [HealthController::class, 'live'])->middleware('throttle:120,1');
+            // Liveness must remain process/request-only: a database-backed cache
+            // makes the normal throttle middleware a database dependency.
+            Route::get('/health/live', [HealthController::class, 'live']);
             Route::get('/health/ready', [HealthController::class, 'ready'])->middleware('throttle:30,1');
         },
     )
@@ -61,7 +63,7 @@ return Application::configure(basePath: dirname(__DIR__))
         // here meant TRUSTED_PROXIES in .env was silently ignored in production
         // (reported in #7).
         $middleware->replace(
-            \Illuminate\Http\Middleware\TrustProxies::class,
+            TrustProxies::class,
             TrustConfiguredProxies::class,
         );
     })

--- a/config/health.php
+++ b/config/health.php
@@ -1,0 +1,10 @@
+<?php
+
+return [
+    // Kept separate because liveness is inexpensive while readiness opens
+    // database and TCP dependency checks.
+    'probe_limits' => [
+        'live' => 120,
+        'ready' => 30,
+    ],
+];

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true">
+    <testsuites>
+        <testsuite name="Feature">
+            <directory>tests/Feature</directory>
+        </testsuite>
+    </testsuites>
+    <php>
+        <env name="APP_ENV" value="testing"/>
+        <env name="APP_KEY" value="base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="/>
+        <env name="CACHE_STORE" value="array"/>
+        <env name="SESSION_DRIVER" value="array"/>
+        <env name="QUEUE_CONNECTION" value="sync"/>
+        <env name="DB_CONNECTION" value="sqlite"/>
+        <env name="DB_DATABASE" value=":memory:"/>
+    </php>
+</phpunit>

--- a/tests/Feature/HealthEndpointsTest.php
+++ b/tests/Feature/HealthEndpointsTest.php
@@ -1,10 +1,14 @@
 <?php
 
+use App\Contracts\HealthProbeLimiter;
 use App\Contracts\TcpProbe;
 use App\Models\Setting;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Schema;
 
 beforeEach(function () {
+    Cache::store('file')->flush();
+
     Schema::create('settings', function ($table) {
         $table->string('key')->primary();
         $table->text('value')->nullable();
@@ -13,6 +17,13 @@ beforeEach(function () {
 
     config()->set('cortendesk.id_server', 'id.example.test:21116');
     config()->set('cortendesk.relay_server', 'relay.example.test:21117');
+});
+
+test('health routes attach the dedicated probe limiter middleware', function () {
+    $routes = collect($this->app['router']->getRoutes()->getRoutes())->keyBy(fn ($route) => $route->uri());
+
+    expect($routes['health/live']->gatherMiddleware())->toContain('health-probe:live');
+    expect($routes['health/ready']->gatherMiddleware())->toContain('health-probe:ready');
 });
 
 test('liveness is public and proves the application can serve a request', function () {
@@ -25,6 +36,20 @@ test('liveness remains process-only when the default database cache is unavailab
     config()->set('cache.default', 'database');
     config()->set('cache.stores.database.table', 'unavailable_cache');
     app('cache')->forgetDriver('database');
+
+    $this->getJson('/health/live')
+        ->assertOk()
+        ->assertExactJson(['live' => true]);
+});
+
+test('liveness remains process-only when the health probe limiter backend fails', function () {
+    $this->app->instance(HealthProbeLimiter::class, new class implements HealthProbeLimiter
+    {
+        public function allows(string $endpoint, string $identity, int $maximumAttempts): bool
+        {
+            throw new RuntimeException('file cache is unavailable');
+        }
+    });
 
     $this->getJson('/health/live')
         ->assertOk()
@@ -47,6 +72,37 @@ test('readiness returns 503 dependency booleans when the database and database c
 
     $this->getJson('/health/ready')
         ->assertServiceUnavailable()
+        ->assertExactJson([
+            'ready' => false,
+            'database' => false,
+            'id_server' => false,
+            'relay_server' => false,
+        ]);
+});
+
+test('liveness is rate limited with a booleans-only liveness response', function () {
+    config()->set('health.probe_limits.live', 2);
+
+    $this->getJson('/health/live')->assertOk();
+    $this->getJson('/health/live')->assertOk();
+    $this->getJson('/health/live')
+        ->assertTooManyRequests()
+        ->assertExactJson(['live' => false]);
+});
+
+test('readiness has its own rate limit with a booleans-only readiness response', function () {
+    config()->set('health.probe_limits.ready', 1);
+    $this->app->instance(TcpProbe::class, new class implements TcpProbe
+    {
+        public function check(string $host, int $port, float $timeout): array
+        {
+            return ['ok' => true, 'latency_ms' => 1, 'error' => null];
+        }
+    });
+
+    $this->getJson('/health/ready')->assertOk();
+    $this->getJson('/health/ready')
+        ->assertTooManyRequests()
         ->assertExactJson([
             'ready' => false,
             'database' => false,

--- a/tests/Feature/HealthEndpointsTest.php
+++ b/tests/Feature/HealthEndpointsTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Contracts\TcpProbe;
+use App\Models\Setting;
 use Illuminate\Support\Facades\Schema;
 
 beforeEach(function () {
@@ -20,7 +21,64 @@ test('liveness is public and proves the application can serve a request', functi
         ->assertExactJson(['live' => true]);
 });
 
-test('readiness returns only dependency booleans when configured dependencies are available', function () {
+test('liveness remains process-only when the default database cache is unavailable', function () {
+    config()->set('cache.default', 'database');
+    config()->set('cache.stores.database.table', 'unavailable_cache');
+    app('cache')->forgetDriver('database');
+
+    $this->getJson('/health/live')
+        ->assertOk()
+        ->assertExactJson(['live' => true]);
+});
+
+test('readiness returns only dependency booleans when every configured relay in the operative pool is available', function () {
+    Setting::put('relay_servers', json_encode([
+        ['address' => 'relay-one.example.test:21117', 'geo' => 'one'],
+        ['address' => 'relay-two.example.test:21117', 'geo' => 'two'],
+    ]));
+    $this->app->instance(TcpProbe::class, new class implements TcpProbe
+    {
+        public function check(string $host, int $port, float $timeout): array
+        {
+            return ['ok' => true, 'latency_ms' => 1, 'error' => null];
+        }
+    });
+
+    $this->getJson('/health/ready')
+        ->assertOk()
+        ->assertExactJson([
+            'ready' => true,
+            'database' => true,
+            'id_server' => true,
+            'relay_server' => true,
+        ]);
+});
+
+test('readiness requires every configured relay in the operative relay pool to be available', function () {
+    Setting::put('relay_servers', json_encode([
+        ['address' => 'relay-one.example.test:21117', 'geo' => 'one'],
+        ['address' => 'relay-two.example.test:21117', 'geo' => 'two'],
+    ]));
+    $this->app->instance(TcpProbe::class, new class implements TcpProbe
+    {
+        public function check(string $host, int $port, float $timeout): array
+        {
+            return ['ok' => $host !== 'relay-two.example.test', 'latency_ms' => 1, 'error' => 'Connection refused'];
+        }
+    });
+
+    $this->getJson('/health/ready')
+        ->assertServiceUnavailable()
+        ->assertExactJson([
+            'ready' => false,
+            'database' => true,
+            'id_server' => true,
+            'relay_server' => false,
+        ]);
+});
+
+test('readiness is not blocked by an absent relay configuration', function () {
+    config()->set('cortendesk.relay_server', '');
     $this->app->instance(TcpProbe::class, new class implements TcpProbe
     {
         public function check(string $host, int $port, float $timeout): array

--- a/tests/Feature/HealthEndpointsTest.php
+++ b/tests/Feature/HealthEndpointsTest.php
@@ -3,11 +3,17 @@
 use App\Contracts\HealthProbeLimiter;
 use App\Contracts\TcpProbe;
 use App\Models\Setting;
+use App\Services\FileHealthProbeLimiter;
+use Illuminate\Contracts\Cache\Factory as CacheFactory;
+use Illuminate\Contracts\Cache\Lock;
+use Illuminate\Contracts\Cache\LockTimeoutException;
+use Illuminate\Contracts\Cache\Repository;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Schema;
 
 beforeEach(function () {
     Cache::store('file')->flush();
+    Schema::dropIfExists('settings');
 
     Schema::create('settings', function ($table) {
         $table->string('key')->primary();
@@ -87,7 +93,45 @@ test('liveness is rate limited with a booleans-only liveness response', function
     $this->getJson('/health/live')->assertOk();
     $this->getJson('/health/live')
         ->assertTooManyRequests()
+        ->assertHeader('Retry-After', '60')
         ->assertExactJson(['live' => false]);
+});
+
+test('liveness uses one endpoint bucket despite forwarded client rotation from a private proxy', function () {
+    config()->set('health.probe_limits.live', 2);
+
+    $this->withServerVariables([
+        'REMOTE_ADDR' => '10.0.0.10',
+        'HTTP_X_FORWARDED_FOR' => '198.51.100.1',
+    ])->getJson('/health/live')->assertOk();
+
+    $this->withServerVariables([
+        'REMOTE_ADDR' => '10.0.0.10',
+        'HTTP_X_FORWARDED_FOR' => '198.51.100.2',
+    ])->getJson('/health/live')->assertOk();
+
+    $this->withServerVariables([
+        'REMOTE_ADDR' => '10.0.0.10',
+        'HTTP_X_FORWARDED_FOR' => '198.51.100.3',
+    ])->getJson('/health/live')
+        ->assertTooManyRequests()
+        ->assertHeader('Retry-After', '60')
+        ->assertExactJson(['live' => false]);
+});
+
+test('a contended limiter lock rejects rather than freely allowing the request', function () {
+    $lock = Mockery::mock(Lock::class);
+    $lock->shouldReceive('block')->once()
+        ->with(1, Mockery::type(Closure::class))
+        ->andThrow(new LockTimeoutException);
+
+    $store = Mockery::mock(Repository::class);
+    $store->shouldReceive('lock')->once()->andReturn($lock);
+
+    $cache = Mockery::mock(CacheFactory::class);
+    $cache->shouldReceive('store')->once()->with('file')->andReturn($store);
+
+    expect((new FileHealthProbeLimiter($cache))->allows('live', 'global', 1))->toBeFalse();
 });
 
 test('readiness has its own rate limit with a booleans-only readiness response', function () {
@@ -103,6 +147,7 @@ test('readiness has its own rate limit with a booleans-only readiness response',
     $this->getJson('/health/ready')->assertOk();
     $this->getJson('/health/ready')
         ->assertTooManyRequests()
+        ->assertHeader('Retry-After', '60')
         ->assertExactJson([
             'ready' => false,
             'database' => false,

--- a/tests/Feature/HealthEndpointsTest.php
+++ b/tests/Feature/HealthEndpointsTest.php
@@ -31,6 +31,30 @@ test('liveness remains process-only when the default database cache is unavailab
         ->assertExactJson(['live' => true]);
 });
 
+test('readiness returns 503 dependency booleans when the database and database cache are unavailable', function () {
+    config()->set('database.default', 'health_unavailable');
+    config()->set('database.connections.health_unavailable', [
+        'driver' => 'sqlite',
+        'database' => '/tmp/cortendesk-health-unavailable/database.sqlite',
+        'prefix' => '',
+        'foreign_key_constraints' => true,
+    ]);
+    config()->set('cache.default', 'database');
+    config()->set('cache.stores.database.connection', 'health_unavailable');
+    config()->set('cache.stores.database.table', 'unavailable_cache');
+    app('db')->purge('health_unavailable');
+    app('cache')->forgetDriver('database');
+
+    $this->getJson('/health/ready')
+        ->assertServiceUnavailable()
+        ->assertExactJson([
+            'ready' => false,
+            'database' => false,
+            'id_server' => false,
+            'relay_server' => false,
+        ]);
+});
+
 test('readiness returns only dependency booleans when every configured relay in the operative pool is available', function () {
     Setting::put('relay_servers', json_encode([
         ['address' => 'relay-one.example.test:21117', 'geo' => 'one'],

--- a/tests/Feature/HealthEndpointsTest.php
+++ b/tests/Feature/HealthEndpointsTest.php
@@ -1,0 +1,59 @@
+<?php
+
+use App\Contracts\TcpProbe;
+use Illuminate\Support\Facades\Schema;
+
+beforeEach(function () {
+    Schema::create('settings', function ($table) {
+        $table->string('key')->primary();
+        $table->text('value')->nullable();
+        $table->timestamps();
+    });
+
+    config()->set('cortendesk.id_server', 'id.example.test:21116');
+    config()->set('cortendesk.relay_server', 'relay.example.test:21117');
+});
+
+test('liveness is public and proves the application can serve a request', function () {
+    $this->getJson('/health/live')
+        ->assertOk()
+        ->assertExactJson(['live' => true]);
+});
+
+test('readiness returns only dependency booleans when configured dependencies are available', function () {
+    $this->app->instance(TcpProbe::class, new class implements TcpProbe
+    {
+        public function check(string $host, int $port, float $timeout): array
+        {
+            return ['ok' => true, 'latency_ms' => 1, 'error' => null];
+        }
+    });
+
+    $this->getJson('/health/ready')
+        ->assertOk()
+        ->assertExactJson([
+            'ready' => true,
+            'database' => true,
+            'id_server' => true,
+            'relay_server' => true,
+        ]);
+});
+
+test('readiness returns 503 with only dependency booleans when a configured service is unavailable', function () {
+    $this->app->instance(TcpProbe::class, new class implements TcpProbe
+    {
+        public function check(string $host, int $port, float $timeout): array
+        {
+            return ['ok' => $host !== 'relay.example.test', 'latency_ms' => 1, 'error' => 'Connection refused'];
+        }
+    });
+
+    $this->getJson('/health/ready')
+        ->assertServiceUnavailable()
+        ->assertExactJson([
+            'ready' => false,
+            'database' => true,
+            'id_server' => true,
+            'relay_server' => false,
+        ]);
+});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,0 +1,5 @@
+<?php
+
+use Tests\TestCase;
+
+pest()->extend(TestCase::class)->in('Feature');

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Tests;
+
+use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
+
+abstract class TestCase extends BaseTestCase {}


### PR DESCRIPTION
## Summary

- add public `GET /health/live` and `GET /health/ready` probes
- return only dependency booleans, with readiness using HTTP 200/503
- check the database, ID server, and every configured active relay
- point the Docker health check at `/health/ready`
- add dependency-safe rate limiting with separate global endpoint buckets

## Safety

- health routes bypass session/database-backed web middleware
- the limiter explicitly uses the persistent file cache rather than the configured default store
- ordinary lock contention is bounded and rejected; genuine limiter backend failures fail open
- liveness stays available during database/default database-cache outages
- readiness exposes no hostnames, ports, timings, versions, errors, or fleet details
- 429 responses retain boolean-only bodies and include `Retry-After: 60`

## Verification

- `php artisan test` — **13 passed, 39 assertions**
- scoped Pint — passed
- config cache and route cache — passed
- `git diff --check` — passed
- final independent spec and code-quality review — approved

Docker was unavailable in the development environment, so the Dockerfile health-check change was statically reviewed rather than image-built.

Closes #48
