### PR TITLE
Add presence alert grace and maintenance snoozes

### DIFF
--- a/app/Console/Commands/CheckDeviceNotifications.php
+++ b/app/Console/Commands/CheckDeviceNotifications.php
@@ -30,13 +30,11 @@ class CheckDeviceNotifications extends Command
         $recovered = 0;
 
         Device::query()->approved()->orderBy('id')->each(function (Device $device) use ($notifications, &$offline, &$recovered): void {
-            $state = DevicePresenceNotificationState::query()->firstOrNew(['device_id' => $device->id]);
-
             if ($device->isOnline()) {
-                if ($state->exists) {
-                    // A maintenance window suppresses both halves of a presence
-                    // transition. Clearing here also prevents a late recovery
-                    // after the window expires.
+                // Claim before sending: this one-statement conditional delete
+                // lets only the scheduler or a concurrent heartbeat own the
+                // paired recovery. A snooze still consumes the marker silently.
+                if (DevicePresenceNotificationState::consumeFor($device)) {
                     if (! DevicePresenceSnooze::isActiveFor($device)) {
                         $notifications->send(
                             'device.online',
@@ -47,12 +45,12 @@ class CheckDeviceNotifications extends Command
                         );
                         $recovered++;
                     }
-
-                    $state->delete();
                 }
 
                 return;
             }
+
+            $state = DevicePresenceNotificationState::query()->firstOrNew(['device_id' => $device->id]);
 
             if ($state->exists || DevicePresenceSnooze::isActiveFor($device) || ! $this->pastOfflineGrace($device)) {
                 return;
@@ -90,8 +88,9 @@ class CheckDeviceNotifications extends Command
             return;
         }
 
-        $state = DevicePresenceNotificationState::query()->where('device_id', $device->id)->first();
-        if ($state === null) {
+        // Atomically claim the marker before queuing transport work. A scheduler
+        // sweep racing this heartbeat receives false and emits nothing.
+        if (! DevicePresenceNotificationState::consumeFor($device)) {
             return;
         }
 
@@ -107,8 +106,6 @@ class CheckDeviceNotifications extends Command
                 $device,
             );
         }
-
-        $state->delete();
     }
 
     public static function deviceLabel(Device $device): string

--- a/app/Console/Commands/CheckDeviceNotifications.php
+++ b/app/Console/Commands/CheckDeviceNotifications.php
@@ -10,6 +10,7 @@ use App\Models\Setting;
 use App\Services\AppriseNotifications;
 use Illuminate\Console\Command;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Cache;
 
 /** Detect device presence transitions for Apprise notifications. */
 class CheckDeviceNotifications extends Command
@@ -20,22 +21,34 @@ class CheckDeviceNotifications extends Command
 
     public function handle(AppriseNotifications $notifications): int
     {
+        DevicePresenceSnooze::pruneForSweep();
+
         if (! $notifications->isEnabledFor('device.offline') && ! $notifications->isEnabledFor('device.online')) {
             $this->info('Device presence notifications are disabled.');
 
             return self::SUCCESS;
         }
 
+        // These inputs are deliberately loaded once. The sweep must not turn
+        // grace/state/snooze checks into a query per device.
+        $graceMinutes = $this->offlineGraceMinutes();
+        $snoozedTargets = DevicePresenceSnooze::activeTargets();
+        $states = DevicePresenceNotificationState::query()->get()->keyBy('device_id');
         $offline = 0;
         $recovered = 0;
 
-        Device::query()->approved()->orderBy('id')->each(function (Device $device) use ($notifications, &$offline, &$recovered): void {
+        Device::query()->approved()->orderBy('id')->each(function (Device $device) use ($notifications, $graceMinutes, $snoozedTargets, $states, &$offline, &$recovered): void {
+            $state = $states->get($device->id);
+            $snoozed = isset($snoozedTargets[DevicePresenceSnooze::TARGET_DEVICE][$device->id])
+                || ($device->device_group_id !== null && isset($snoozedTargets[DevicePresenceSnooze::TARGET_GROUP][$device->device_group_id]));
+
             if ($device->isOnline()) {
-                // Claim before sending: this one-statement conditional delete
-                // lets only the scheduler or a concurrent heartbeat own the
-                // paired recovery. A snooze still consumes the marker silently.
-                if (DevicePresenceNotificationState::consumeFor($device)) {
-                    if (! DevicePresenceSnooze::isActiveFor($device)) {
+                if (($state?->offline_notified_at !== null || Cache::has(self::legacyMarkerKey($device)))
+                    && self::consumeRecoveryFor($device)) {
+                    // Recovery is at-most-once: consumeRecoveryFor removes the
+                    // marker before transport, so a failed recovery is never
+                    // retried and concurrent commands cannot duplicate it.
+                    if (! $snoozed) {
                         $notifications->send(
                             'device.online',
                             'Device recovered',
@@ -50,9 +63,22 @@ class CheckDeviceNotifications extends Command
                 return;
             }
 
-            $state = DevicePresenceNotificationState::query()->firstOrNew(['device_id' => $device->id]);
+            if ($state?->offline_notified_at !== null || $snoozed || ! $this->pastOfflineGrace($device, $graceMinutes)) {
+                return;
+            }
 
-            if ($state->exists || DevicePresenceSnooze::isActiveFor($device) || ! $this->pastOfflineGrace($device)) {
+            if (Cache::has(self::legacyMarkerKey($device))) {
+                // Keep the bounded 30-day legacy marker until online. The
+                // durable marker prevents another offline send after upgrade.
+                DevicePresenceNotificationState::recordLegacyOffline($device);
+
+                return;
+            }
+
+            // Insert/reclaim a unique durable pending row before calling the
+            // external service. Only its owner may complete or release it.
+            $claim = DevicePresenceNotificationState::claimOfflineFor($device);
+            if ($claim === null) {
                 return;
             }
 
@@ -64,15 +90,11 @@ class CheckDeviceNotifications extends Command
                 $device,
             );
 
-            // Only a confirmed send creates the durable outage marker. A failed,
-            // disabled, scoped-out, or cooldown-suppressed send cannot produce a
-            // recovery alert later, and can be retried by a future sweep.
-            if ($delivery?->status === NotificationDelivery::STATUS_SENT) {
-                DevicePresenceNotificationState::query()->create([
-                    'device_id' => $device->id,
-                    'offline_notified_at' => now(),
-                ]);
+            if ($delivery?->status === NotificationDelivery::STATUS_SENT
+                && DevicePresenceNotificationState::markDelivered($device, $claim)) {
                 $offline++;
+            } else {
+                DevicePresenceNotificationState::releaseClaim($device, $claim);
             }
         });
 
@@ -84,20 +106,13 @@ class CheckDeviceNotifications extends Command
     /** Notify recovery on the first heartbeat after a confirmed offline delivery. */
     public static function reportOnline(Device $device, AppriseNotifications $notifications): void
     {
-        if ($device->status !== Device::STATUS_ACTIVE) {
+        if ($device->status !== Device::STATUS_ACTIVE || ! self::consumeRecoveryFor($device)) {
             return;
         }
 
-        // Atomically claim the marker before queuing transport work. A scheduler
-        // sweep racing this heartbeat receives false and emits nothing.
-        if (! DevicePresenceNotificationState::consumeFor($device)) {
-            return;
-        }
-
-        // See handle(): a snooze closes the outage without emitting either side.
+        // A snooze closes the outage without emitting either side. Recovery is
+        // at-most-once because the marker was atomically consumed above.
         if (! DevicePresenceSnooze::isActiveFor($device)) {
-            // Called from heartbeat/sysinfo endpoints, so keep transport work
-            // after the HTTP response has been flushed.
             $notifications->sendAfterResponse(
                 'device.online',
                 'Device recovered',
@@ -115,13 +130,49 @@ class CheckDeviceNotifications extends Command
         return $name === '' ? 'Device '.$device->rustdesk_id : $name.' ('.$device->rustdesk_id.')';
     }
 
-    private function pastOfflineGrace(Device $device): bool
+    /** Consume a durable marker or the bounded legacy cache fallback once. */
+    private static function consumeRecoveryFor(Device $device): bool
+    {
+        if (DevicePresenceNotificationState::consumeFor($device)) {
+            Cache::forget(self::legacyMarkerKey($device));
+
+            return true;
+        }
+
+        // Cache::pull() alone is not atomic on every supported cache driver.
+        // Claim the legacy marker first; a crashed consumer only delays retry by
+        // this short timeout while the original 30-day marker remains bounded.
+        $claimKey = self::legacyClaimKey($device);
+        if (! Cache::add($claimKey, true, DevicePresenceNotificationState::CLAIM_TIMEOUT_SECONDS)) {
+            return false;
+        }
+
+        if (Cache::pull(self::legacyMarkerKey($device)) !== null) {
+            return true;
+        }
+
+        Cache::forget($claimKey);
+
+        return false;
+    }
+
+    private static function legacyClaimKey(Device $device): string
+    {
+        return 'apprise:device-offline-claim:'.sha1($device->rustdesk_id);
+    }
+
+    private static function legacyMarkerKey(Device $device): string
+    {
+        return 'apprise:device-offline:'.sha1($device->rustdesk_id);
+    }
+
+    private function pastOfflineGrace(Device $device, int $graceMinutes): bool
     {
         $offlineSince = $device->last_online_at?->copy()->addSeconds(Device::onlineWindow())
             ?? $device->created_at;
 
         return $offlineSince instanceof Carbon
-            && $offlineSince->addMinutes($this->offlineGraceMinutes())->lte(now());
+            && $offlineSince->addMinutes($graceMinutes)->lte(now());
     }
 
     private function offlineGraceMinutes(): int

--- a/app/Console/Commands/CheckDeviceNotifications.php
+++ b/app/Console/Commands/CheckDeviceNotifications.php
@@ -10,7 +10,6 @@ use App\Models\Setting;
 use App\Services\AppriseNotifications;
 use Illuminate\Console\Command;
 use Illuminate\Support\Carbon;
-use Illuminate\Support\Facades\Cache;
 
 /** Detect device presence transitions for Apprise notifications. */
 class CheckDeviceNotifications extends Command
@@ -43,8 +42,7 @@ class CheckDeviceNotifications extends Command
                 || ($device->device_group_id !== null && isset($snoozedTargets[DevicePresenceSnooze::TARGET_GROUP][$device->device_group_id]));
 
             if ($device->isOnline()) {
-                if (($state?->offline_notified_at !== null || Cache::has(self::legacyMarkerKey($device)))
-                    && self::consumeRecoveryFor($device)) {
+                if (self::consumeRecoveryFor($device)) {
                     // Recovery is at-most-once: consumeRecoveryFor removes the
                     // marker before transport, so a failed recovery is never
                     // retried and concurrent commands cannot duplicate it.
@@ -67,10 +65,16 @@ class CheckDeviceNotifications extends Command
                 return;
             }
 
-            if (Cache::has(self::legacyMarkerKey($device))) {
-                // Keep the bounded 30-day legacy marker until online. The
-                // durable marker prevents another offline send after upgrade.
-                DevicePresenceNotificationState::recordLegacyOffline($device);
+            // The legacy marker belongs to exactly one contender. A sweep
+            // winner consumes it before materializing delivered state; an
+            // online recovery winner consumes it for its sole recovery.
+            $legacyClaim = DevicePresenceNotificationState::claimLegacyMarkerFor($device);
+            if ($legacyClaim === null) {
+                return;
+            }
+
+            if (is_string($legacyClaim)) {
+                DevicePresenceNotificationState::convertClaimedLegacyMarkerFor($device, $legacyClaim);
 
                 return;
             }
@@ -130,40 +134,27 @@ class CheckDeviceNotifications extends Command
         return $name === '' ? 'Device '.$device->rustdesk_id : $name.' ('.$device->rustdesk_id.')';
     }
 
-    /** Consume a durable marker or the bounded legacy cache fallback once. */
+    /** Consume a durable marker or the shared legacy claim exactly once. */
     private static function consumeRecoveryFor(Device $device): bool
     {
-        if (DevicePresenceNotificationState::consumeFor($device)) {
-            Cache::forget(self::legacyMarkerKey($device));
+        $legacyClaim = DevicePresenceNotificationState::claimLegacyMarkerFor($device);
 
-            return true;
-        }
-
-        // Cache::pull() alone is not atomic on every supported cache driver.
-        // Claim the legacy marker first; a crashed consumer only delays retry by
-        // this short timeout while the original 30-day marker remains bounded.
-        $claimKey = self::legacyClaimKey($device);
-        if (! Cache::add($claimKey, true, DevicePresenceNotificationState::CLAIM_TIMEOUT_SECONDS)) {
+        // A claimant may be converting the marker into durable state. Let that
+        // winner finish rather than deleting state it is about to materialize.
+        if ($legacyClaim === null) {
             return false;
         }
 
-        if (Cache::pull(self::legacyMarkerKey($device)) !== null) {
-            return true;
+        if ($legacyClaim === false) {
+            return DevicePresenceNotificationState::consumeFor($device);
         }
 
-        Cache::forget($claimKey);
+        // Keep the legacy lock through both deletions. This also cleans up old
+        // upgrades that had durable state plus the original cache marker.
+        $durableRecovery = DevicePresenceNotificationState::consumeFor($device);
+        $legacyRecovery = DevicePresenceNotificationState::consumeClaimedLegacyMarkerFor($device, $legacyClaim);
 
-        return false;
-    }
-
-    private static function legacyClaimKey(Device $device): string
-    {
-        return 'apprise:device-offline-claim:'.sha1($device->rustdesk_id);
-    }
-
-    private static function legacyMarkerKey(Device $device): string
-    {
-        return 'apprise:device-offline:'.sha1($device->rustdesk_id);
+        return $durableRecovery || $legacyRecovery;
     }
 
     private function pastOfflineGrace(Device $device, int $graceMinutes): bool

--- a/app/Console/Commands/CheckDeviceNotifications.php
+++ b/app/Console/Commands/CheckDeviceNotifications.php
@@ -3,23 +3,17 @@
 namespace App\Console\Commands;
 
 use App\Models\Device;
+use App\Models\DevicePresenceNotificationState;
+use App\Models\DevicePresenceSnooze;
+use App\Models\NotificationDelivery;
+use App\Models\Setting;
 use App\Services\AppriseNotifications;
 use Illuminate\Console\Command;
-use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Carbon;
 
-/**
- * Tracks presence transitions for notifications. Device rows intentionally do
- * not carry notification state: cache keys expire after a bounded retention,
- * preserve existing schema semantics, and make disabling/re-enabling alerts
- * innocuous. The online endpoint also clears an offline marker immediately,
- * which means recovery is prompt rather than waiting for this minute sweep.
- */
+/** Detect device presence transitions for Apprise notifications. */
 class CheckDeviceNotifications extends Command
 {
-    public const OFFLINE_MARKER_PREFIX = 'apprise:device-offline:';
-
-    private const MARKER_TTL_DAYS = 30;
-
     protected $signature = 'cortendesk:check-device-notifications';
 
     protected $description = 'Detect device offline/recovery transitions for Apprise notifications';
@@ -36,32 +30,51 @@ class CheckDeviceNotifications extends Command
         $recovered = 0;
 
         Device::query()->approved()->orderBy('id')->each(function (Device $device) use ($notifications, &$offline, &$recovered): void {
-            $marker = self::marker($device->rustdesk_id);
+            $state = DevicePresenceNotificationState::query()->firstOrNew(['device_id' => $device->id]);
 
-            if (! $device->isOnline()) {
-                if (Cache::add($marker, true, now()->addDays(self::MARKER_TTL_DAYS))) {
-                    $notifications->send(
-                        'device.offline',
-                        'Device offline',
-                        self::deviceLabel($device).' stopped heartbeating.',
-                        'device:'.$device->rustdesk_id,
-                        $device,
-                    );
-                    $offline++;
+            if ($device->isOnline()) {
+                if ($state->exists) {
+                    // A maintenance window suppresses both halves of a presence
+                    // transition. Clearing here also prevents a late recovery
+                    // after the window expires.
+                    if (! DevicePresenceSnooze::isActiveFor($device)) {
+                        $notifications->send(
+                            'device.online',
+                            'Device recovered',
+                            self::deviceLabel($device).' is online again.',
+                            'device:'.$device->rustdesk_id,
+                            $device,
+                        );
+                        $recovered++;
+                    }
+
+                    $state->delete();
                 }
 
                 return;
             }
 
-            if (Cache::pull($marker)) {
-                $notifications->send(
-                    'device.online',
-                    'Device recovered',
-                    self::deviceLabel($device).' is online again.',
-                    'device:'.$device->rustdesk_id,
-                    $device,
-                );
-                $recovered++;
+            if ($state->exists || DevicePresenceSnooze::isActiveFor($device) || ! $this->pastOfflineGrace($device)) {
+                return;
+            }
+
+            $delivery = $notifications->send(
+                'device.offline',
+                'Device offline',
+                self::deviceLabel($device).' stopped heartbeating.',
+                'device:'.$device->rustdesk_id,
+                $device,
+            );
+
+            // Only a confirmed send creates the durable outage marker. A failed,
+            // disabled, scoped-out, or cooldown-suppressed send cannot produce a
+            // recovery alert later, and can be retried by a future sweep.
+            if ($delivery?->status === NotificationDelivery::STATUS_SENT) {
+                DevicePresenceNotificationState::query()->create([
+                    'device_id' => $device->id,
+                    'offline_notified_at' => now(),
+                ]);
+                $offline++;
             }
         });
 
@@ -70,27 +83,32 @@ class CheckDeviceNotifications extends Command
         return self::SUCCESS;
     }
 
-    /** Notify recovery on the first heartbeat after the scheduled sweep marked a device offline. */
+    /** Notify recovery on the first heartbeat after a confirmed offline delivery. */
     public static function reportOnline(Device $device, AppriseNotifications $notifications): void
     {
-        if ($device->status !== Device::STATUS_ACTIVE || ! Cache::pull(self::marker($device->rustdesk_id))) {
+        if ($device->status !== Device::STATUS_ACTIVE) {
             return;
         }
 
-        // Called from the heartbeat and sysinfo endpoints, so this must not
-        // hold the response open while an unreachable endpoint times out.
-        $notifications->sendAfterResponse(
-            'device.online',
-            'Device recovered',
-            self::deviceLabel($device).' is online again.',
-            'device:'.$device->rustdesk_id,
-            $device,
-        );
-    }
+        $state = DevicePresenceNotificationState::query()->where('device_id', $device->id)->first();
+        if ($state === null) {
+            return;
+        }
 
-    public static function marker(string $rustdeskId): string
-    {
-        return self::OFFLINE_MARKER_PREFIX.sha1($rustdeskId);
+        // See handle(): a snooze closes the outage without emitting either side.
+        if (! DevicePresenceSnooze::isActiveFor($device)) {
+            // Called from heartbeat/sysinfo endpoints, so keep transport work
+            // after the HTTP response has been flushed.
+            $notifications->sendAfterResponse(
+                'device.online',
+                'Device recovered',
+                self::deviceLabel($device).' is online again.',
+                'device:'.$device->rustdesk_id,
+                $device,
+            );
+        }
+
+        $state->delete();
     }
 
     public static function deviceLabel(Device $device): string
@@ -98,5 +116,19 @@ class CheckDeviceNotifications extends Command
         $name = trim((string) ($device->alias ?: $device->hostname));
 
         return $name === '' ? 'Device '.$device->rustdesk_id : $name.' ('.$device->rustdesk_id.')';
+    }
+
+    private function pastOfflineGrace(Device $device): bool
+    {
+        $offlineSince = $device->last_online_at?->copy()->addSeconds(Device::onlineWindow())
+            ?? $device->created_at;
+
+        return $offlineSince instanceof Carbon
+            && $offlineSince->addMinutes($this->offlineGraceMinutes())->lte(now());
+    }
+
+    private function offlineGraceMinutes(): int
+    {
+        return max(0, min(1440, (int) Setting::get('apprise_offline_grace_minutes', '0')));
     }
 }

--- a/app/Livewire/SettingsPage.php
+++ b/app/Livewire/SettingsPage.php
@@ -6,6 +6,7 @@ use App\Livewire\Concerns\AuthorizesConsole;
 use App\Models\ConsoleAudit;
 use App\Models\Device;
 use App\Models\DeviceGroup;
+use App\Models\DevicePresenceSnooze;
 use App\Models\NotificationDelivery;
 use App\Models\Setting;
 use App\Models\UserGroup;
@@ -143,6 +144,16 @@ class SettingsPage extends Component
 
     public int $appriseCooldownMinutes = 15;
 
+    /** Extra minutes a device must remain offline before an alert is sent. */
+    public int $appriseOfflineGraceMinutes = 0;
+
+    /** Device or group selected for a bounded presence-alert maintenance window. */
+    public string $presenceSnoozeTargetType = DevicePresenceSnooze::TARGET_DEVICE;
+
+    public int $presenceSnoozeTargetId = 0;
+
+    public int $presenceSnoozeMinutes = 60;
+
     /** @var array<string, bool> */
     public array $appriseEvents = [];
 
@@ -219,6 +230,7 @@ class SettingsPage extends Component
         $this->appriseConfigKeySet = trim((string) Setting::get('apprise_config_key', '')) !== '';
         $this->appriseUrlsSet = trim((string) Setting::get('apprise_urls', '')) !== '';
         $this->appriseCooldownMinutes = (int) (Setting::get('apprise_cooldown_minutes', '15') ?: 15);
+        $this->appriseOfflineGraceMinutes = (int) (Setting::get('apprise_offline_grace_minutes', '0') ?: 0);
         foreach (AppriseNotifications::EVENTS as $event => $_label) {
             $suffix = str_replace('.', '_', $event);
             $this->appriseEvents[$suffix] = Setting::get('apprise_event_'.$suffix, '0') === '1';
@@ -309,6 +321,7 @@ class SettingsPage extends Component
                 'appriseConfigKey' => 'nullable|string|max:255',
                 'appriseUrls' => 'nullable|string|max:10000',
                 'appriseCooldownMinutes' => 'required|integer|min:0|max:1440',
+                'appriseOfflineGraceMinutes' => 'required|integer|min:0|max:1440',
             ]);
         } catch (ValidationException $e) {
             $this->tab = self::tabForField((string) array_key_first($e->errors())) ?? $this->tab;
@@ -396,6 +409,7 @@ class SettingsPage extends Component
         Setting::put('apprise_enabled', $this->appriseEnabled ? '1' : '0');
         Setting::put('apprise_delivery_mode', $this->appriseMode);
         Setting::put('apprise_cooldown_minutes', (string) $this->appriseCooldownMinutes);
+        Setting::put('apprise_offline_grace_minutes', (string) $this->appriseOfflineGraceMinutes);
         foreach (AppriseNotifications::EVENTS as $event => $_label) {
             $suffix = str_replace('.', '_', $event);
             Setting::put('apprise_event_'.$suffix, ! empty($this->appriseEvents[$suffix]) ? '1' : '0');
@@ -511,6 +525,35 @@ class SettingsPage extends Component
         ConsoleAudit::record('settings.mail-test', 'Sent a test email to '.$to, 'settings', null);
     }
 
+    public function createPresenceSnooze(): void
+    {
+        $this->authorizeConsole('setting', 'rw');
+        $this->validate([
+            'presenceSnoozeTargetType' => 'required|in:device,group',
+            'presenceSnoozeTargetId' => 'required|integer|min:1',
+            'presenceSnoozeMinutes' => 'required|integer|min:15|max:10080',
+        ]);
+
+        $expiresAt = now()->addMinutes($this->presenceSnoozeMinutes);
+        if ($this->presenceSnoozeTargetType === DevicePresenceSnooze::TARGET_DEVICE) {
+            $target = Device::query()->approved()->findOrFail($this->presenceSnoozeTargetId);
+            DevicePresenceSnooze::snoozeDevice($target, $expiresAt);
+        } else {
+            $target = DeviceGroup::query()->findOrFail($this->presenceSnoozeTargetId);
+            DevicePresenceSnooze::snoozeGroup($target, $expiresAt);
+        }
+
+        ConsoleAudit::record('settings.presence-snooze', 'Snoozed device presence alerts until '.$expiresAt->toDateTimeString(), 'settings', null);
+        $this->presenceSnoozeTargetId = 0;
+    }
+
+    public function clearPresenceSnooze(int $id): void
+    {
+        $this->authorizeConsole('setting', 'rw');
+        DevicePresenceSnooze::query()->whereKey($id)->delete();
+        ConsoleAudit::record('settings.presence-snooze-clear', 'Cleared a device presence alert snooze', 'settings', null);
+    }
+
     public function sendTestNotification(): void
     {
         $this->authorizeConsole('setting', 'rw');
@@ -534,6 +577,9 @@ class SettingsPage extends Component
             'appriseDeviceGroups' => DeviceGroup::query()->orderBy('name')->get(['id', 'name']),
             'appriseDevices' => Device::query()->approved()->orderByRaw("COALESCE(NULLIF(alias, ''), NULLIF(hostname, ''), rustdesk_id)")->get(['id', 'rustdesk_id', 'alias', 'hostname']),
             'notificationDeliveries' => NotificationDelivery::query()->latest()->limit(10)->get(),
+            'presenceSnoozes' => DevicePresenceSnooze::query()->active()->orderBy('expires_at')->get(),
+            'presenceSnoozeGroups' => DeviceGroup::query()->orderBy('name')->get(['id', 'name']),
+            'presenceSnoozeDevices' => Device::query()->approved()->orderByRaw("COALESCE(NULLIF(alias, ''), NULLIF(hostname, ''), rustdesk_id)")->get(['id', 'rustdesk_id', 'alias', 'hostname']),
         ]);
     }
 }

--- a/app/Livewire/SettingsPage.php
+++ b/app/Livewire/SettingsPage.php
@@ -527,7 +527,7 @@ class SettingsPage extends Component
 
     public function createPresenceSnooze(): void
     {
-        $this->authorizeConsole('setting', 'rw');
+        $this->authorizePresenceMaintenance();
         $this->validate([
             'presenceSnoozeTargetType' => 'required|in:device,group',
             'presenceSnoozeTargetId' => 'required|integer|min:1',
@@ -549,7 +549,7 @@ class SettingsPage extends Component
 
     public function clearPresenceSnooze(int $id): void
     {
-        $this->authorizeConsole('setting', 'rw');
+        $this->authorizePresenceMaintenance();
         DevicePresenceSnooze::query()->whereKey($id)->delete();
         ConsoleAudit::record('settings.presence-snooze-clear', 'Cleared a device presence alert snooze', 'settings', null);
     }
@@ -565,8 +565,15 @@ class SettingsPage extends Component
         ConsoleAudit::record('settings.notification-test', 'Sent an Apprise test notification', 'settings', null);
     }
 
+    private function authorizePresenceMaintenance(): void
+    {
+        abort_unless(auth()->user()?->is_admin, 403);
+    }
+
     public function render()
     {
+        $isAdmin = (bool) auth()->user()?->is_admin;
+
         return view('livewire.settings-page', [
             'apiUrl' => rtrim(config('app.url'), '/'),
             'userGroups' => UserGroup::query()->orderBy('name')->get(['id', 'name']),
@@ -577,9 +584,9 @@ class SettingsPage extends Component
             'appriseDeviceGroups' => DeviceGroup::query()->orderBy('name')->get(['id', 'name']),
             'appriseDevices' => Device::query()->approved()->orderByRaw("COALESCE(NULLIF(alias, ''), NULLIF(hostname, ''), rustdesk_id)")->get(['id', 'rustdesk_id', 'alias', 'hostname']),
             'notificationDeliveries' => NotificationDelivery::query()->latest()->limit(10)->get(),
-            'presenceSnoozes' => DevicePresenceSnooze::query()->active()->orderBy('expires_at')->get(),
-            'presenceSnoozeGroups' => DeviceGroup::query()->orderBy('name')->get(['id', 'name']),
-            'presenceSnoozeDevices' => Device::query()->approved()->orderByRaw("COALESCE(NULLIF(alias, ''), NULLIF(hostname, ''), rustdesk_id)")->get(['id', 'rustdesk_id', 'alias', 'hostname']),
+            'presenceSnoozes' => $isAdmin ? DevicePresenceSnooze::query()->active()->orderBy('expires_at')->get() : collect(),
+            'presenceSnoozeGroups' => $isAdmin ? DeviceGroup::query()->orderBy('name')->get(['id', 'name']) : collect(),
+            'presenceSnoozeDevices' => $isAdmin ? Device::query()->approved()->orderByRaw("COALESCE(NULLIF(alias, ''), NULLIF(hostname, ''), rustdesk_id)")->get(['id', 'rustdesk_id', 'alias', 'hostname']) : collect(),
         ]);
     }
 }

--- a/app/Models/DevicePresenceNotificationState.php
+++ b/app/Models/DevicePresenceNotificationState.php
@@ -14,6 +14,17 @@ class DevicePresenceNotificationState extends Model
         return ['offline_notified_at' => 'datetime'];
     }
 
+    /**
+     * Atomically consume the single outstanding recovery marker for a device.
+     *
+     * A conditional DELETE is one database statement, so the scheduler and a
+     * concurrent heartbeat cannot both win the right to emit a recovery alert.
+     */
+    public static function consumeFor(Device $device): bool
+    {
+        return static::query()->where('device_id', $device->id)->delete() === 1;
+    }
+
     public function device(): BelongsTo
     {
         return $this->belongsTo(Device::class);

--- a/app/Models/DevicePresenceNotificationState.php
+++ b/app/Models/DevicePresenceNotificationState.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class DevicePresenceNotificationState extends Model
+{
+    protected $fillable = ['device_id', 'offline_notified_at'];
+
+    protected function casts(): array
+    {
+        return ['offline_notified_at' => 'datetime'];
+    }
+
+    public function device(): BelongsTo
+    {
+        return $this->belongsTo(Device::class);
+    }
+}

--- a/app/Models/DevicePresenceNotificationState.php
+++ b/app/Models/DevicePresenceNotificationState.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Str;
 
 class DevicePresenceNotificationState extends Model
@@ -18,6 +19,75 @@ class DevicePresenceNotificationState extends Model
             'offline_notified_at' => 'datetime',
             'offline_claimed_at' => 'datetime',
         ];
+    }
+
+    /**
+     * Atomically claim a bounded legacy cache marker for either conversion or
+     * recovery. Null means another contender owns the short-lived claim; false
+     * means no marker exists. The owner must consume before acting.
+     */
+    public static function claimLegacyMarkerFor(Device $device): string|false|null
+    {
+        $token = (string) Str::uuid();
+        $lock = Cache::lock(static::legacyClaimKey($device), self::CLAIM_TIMEOUT_SECONDS, $token);
+
+        if (! $lock->get()) {
+            return null;
+        }
+
+        if (! Cache::has(static::legacyMarkerKey($device))) {
+            $lock->release();
+
+            return false;
+        }
+
+        return $token;
+    }
+
+    /**
+     * Consume a legacy marker only while this token still owns its claim.
+     *
+     * A process dying before this pull leaves the original marker recoverable
+     * when its lock expires. Once pulled, recovery is deliberately at-most-once.
+     */
+    public static function consumeClaimedLegacyMarkerFor(Device $device, string $token): bool
+    {
+        $lock = Cache::lock(static::legacyClaimKey($device), self::CLAIM_TIMEOUT_SECONDS, $token);
+
+        if (! $lock->isOwnedByCurrentProcess()) {
+            return false;
+        }
+
+        try {
+            return Cache::pull(static::legacyMarkerKey($device)) !== null;
+        } finally {
+            $lock->release();
+        }
+    }
+
+    /**
+     * Consume the marker and materialize its delivered state before releasing
+     * the shared claim, so recovery cannot delete state between those steps.
+     */
+    public static function convertClaimedLegacyMarkerFor(Device $device, string $token): bool
+    {
+        $lock = Cache::lock(static::legacyClaimKey($device), self::CLAIM_TIMEOUT_SECONDS, $token);
+
+        if (! $lock->isOwnedByCurrentProcess()) {
+            return false;
+        }
+
+        try {
+            if (Cache::pull(static::legacyMarkerKey($device)) === null) {
+                return false;
+            }
+
+            static::recordLegacyOffline($device);
+
+            return true;
+        } finally {
+            $lock->release();
+        }
     }
 
     /** Preserve a delivered offline marker from the legacy 30-day cache key. */
@@ -102,6 +172,16 @@ class DevicePresenceNotificationState extends Model
             ->where('device_id', $device->id)
             ->whereNotNull('offline_notified_at')
             ->delete() === 1;
+    }
+
+    private static function legacyClaimKey(Device $device): string
+    {
+        return 'apprise:device-offline-claim:'.sha1($device->rustdesk_id);
+    }
+
+    private static function legacyMarkerKey(Device $device): string
+    {
+        return 'apprise:device-offline:'.sha1($device->rustdesk_id);
     }
 
     public function device(): BelongsTo

--- a/app/Models/DevicePresenceNotificationState.php
+++ b/app/Models/DevicePresenceNotificationState.php
@@ -4,25 +4,104 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Str;
 
 class DevicePresenceNotificationState extends Model
 {
-    protected $fillable = ['device_id', 'offline_notified_at'];
+    public const CLAIM_TIMEOUT_SECONDS = 300;
+
+    protected $fillable = ['device_id', 'offline_notified_at', 'offline_claim_token', 'offline_claimed_at'];
 
     protected function casts(): array
     {
-        return ['offline_notified_at' => 'datetime'];
+        return [
+            'offline_notified_at' => 'datetime',
+            'offline_claimed_at' => 'datetime',
+        ];
+    }
+
+    /** Preserve a delivered offline marker from the legacy 30-day cache key. */
+    public static function recordLegacyOffline(Device $device): void
+    {
+        $now = now();
+        static::query()->insertOrIgnore([
+            'device_id' => $device->id,
+            'offline_notified_at' => $now,
+            'created_at' => $now,
+            'updated_at' => $now,
+        ]);
+    }
+
+    /**
+     * Atomically acquire the right to attempt one offline delivery.
+     *
+     * The unique device row is inserted pending before transport starts. A dead
+     * worker's pending row is reclaimable after a short bounded timeout.
+     */
+    public static function claimOfflineFor(Device $device): ?string
+    {
+        $token = (string) Str::uuid();
+        $now = now();
+
+        if (static::query()->insertOrIgnore([
+            'device_id' => $device->id,
+            'offline_claim_token' => $token,
+            'offline_claimed_at' => $now,
+            'created_at' => $now,
+            'updated_at' => $now,
+        ]) === 1) {
+            return $token;
+        }
+
+        $reclaimed = static::query()
+            ->where('device_id', $device->id)
+            ->whereNull('offline_notified_at')
+            ->where('offline_claimed_at', '<=', $now->copy()->subSeconds(self::CLAIM_TIMEOUT_SECONDS))
+            ->update([
+                'offline_claim_token' => $token,
+                'offline_claimed_at' => $now,
+                'updated_at' => $now,
+            ]);
+
+        return $reclaimed === 1 ? $token : null;
+    }
+
+    /** Mark delivery only when this contender still owns the pending claim. */
+    public static function markDelivered(Device $device, string $token): bool
+    {
+        return static::query()
+            ->where('device_id', $device->id)
+            ->whereNull('offline_notified_at')
+            ->where('offline_claim_token', $token)
+            ->update([
+                'offline_notified_at' => now(),
+                'offline_claim_token' => null,
+                'offline_claimed_at' => null,
+                'updated_at' => now(),
+            ]) === 1;
+    }
+
+    /** Release a failed, disabled, scoped, or cooldown-suppressed owned claim. */
+    public static function releaseClaim(Device $device, string $token): bool
+    {
+        return static::query()
+            ->where('device_id', $device->id)
+            ->whereNull('offline_notified_at')
+            ->where('offline_claim_token', $token)
+            ->delete() === 1;
     }
 
     /**
      * Atomically consume the single outstanding recovery marker for a device.
-     *
-     * A conditional DELETE is one database statement, so the scheduler and a
-     * concurrent heartbeat cannot both win the right to emit a recovery alert.
+     * Recovery is deliberately at-most-once: once consumed, a failed transport
+     * is not retried because a second consumer must never send a duplicate.
      */
     public static function consumeFor(Device $device): bool
     {
-        return static::query()->where('device_id', $device->id)->delete() === 1;
+        return static::query()
+            ->where('device_id', $device->id)
+            ->whereNotNull('offline_notified_at')
+            ->delete() === 1;
     }
 
     public function device(): BelongsTo

--- a/app/Models/DevicePresenceSnooze.php
+++ b/app/Models/DevicePresenceSnooze.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Carbon;
+
+/** A bounded maintenance window for device presence alerts only. */
+class DevicePresenceSnooze extends Model
+{
+    public const TARGET_DEVICE = 'device';
+
+    public const TARGET_GROUP = 'group';
+
+    protected $fillable = ['target_type', 'target_id', 'expires_at'];
+
+    protected function casts(): array
+    {
+        return ['expires_at' => 'datetime'];
+    }
+
+    public function scopeActive(Builder $query): Builder
+    {
+        return $query->where('expires_at', '>', now());
+    }
+
+    public static function snoozeDevice(Device $device, Carbon $expiresAt): self
+    {
+        return self::put(self::TARGET_DEVICE, (int) $device->id, $expiresAt);
+    }
+
+    public static function snoozeGroup(DeviceGroup $group, Carbon $expiresAt): self
+    {
+        return self::put(self::TARGET_GROUP, (int) $group->id, $expiresAt);
+    }
+
+    public static function isActiveFor(Device $device): bool
+    {
+        return self::query()->active()->where(function (Builder $query) use ($device): void {
+            $query->where(fn (Builder $query) => $query
+                ->where('target_type', self::TARGET_DEVICE)
+                ->where('target_id', $device->id));
+
+            if ($device->device_group_id !== null) {
+                $query->orWhere(fn (Builder $query) => $query
+                    ->where('target_type', self::TARGET_GROUP)
+                    ->where('target_id', $device->device_group_id));
+            }
+        })->exists();
+    }
+
+    private static function put(string $type, int $id, Carbon $expiresAt): self
+    {
+        return self::query()->updateOrCreate(
+            ['target_type' => $type, 'target_id' => $id],
+            ['expires_at' => $expiresAt],
+        );
+    }
+}

--- a/app/Models/DevicePresenceSnooze.php
+++ b/app/Models/DevicePresenceSnooze.php
@@ -35,6 +35,40 @@ class DevicePresenceSnooze extends Model
         return self::put(self::TARGET_GROUP, (int) $group->id, $expiresAt);
     }
 
+    /** Remove expired windows and bounded old targets deleted outside normal UI flows. */
+    public static function pruneForSweep(): void
+    {
+        static::query()->where('expires_at', '<=', now())->delete();
+
+        static::query()
+            ->where('created_at', '<=', now()->subDays(7))
+            ->where(function (Builder $query): void {
+                $query->where(function (Builder $query): void {
+                    $query->where('target_type', self::TARGET_DEVICE)
+                        ->whereNotExists(fn ($subquery) => $subquery->selectRaw('1')
+                            ->from('devices')
+                            ->whereColumn('devices.id', 'device_presence_snoozes.target_id'));
+                })->orWhere(function (Builder $query): void {
+                    $query->where('target_type', self::TARGET_GROUP)
+                        ->whereNotExists(fn ($subquery) => $subquery->selectRaw('1')
+                            ->from('device_groups')
+                            ->whereColumn('device_groups.id', 'device_presence_snoozes.target_id'));
+                });
+            })->delete();
+    }
+
+    /** @return array{device: array<int, true>, group: array<int, true>} */
+    public static function activeTargets(): array
+    {
+        $targets = [self::TARGET_DEVICE => [], self::TARGET_GROUP => []];
+
+        static::query()->active()->get(['target_type', 'target_id'])->each(function (self $snooze) use (&$targets): void {
+            $targets[$snooze->target_type][(int) $snooze->target_id] = true;
+        });
+
+        return $targets;
+    }
+
     public static function isActiveFor(Device $device): bool
     {
         return self::query()->active()->where(function (Builder $query) use ($device): void {

--- a/database/migrations/2026_08_21_000020_create_device_presence_notification_state_tables.php
+++ b/database/migrations/2026_08_21_000020_create_device_presence_notification_state_tables.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('device_presence_notification_states', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('device_id')->unique()->constrained()->cascadeOnDelete();
+            // Set only after Apprise records a successful offline delivery. This
+            // durable marker survives cache eviction and process restarts.
+            $table->timestamp('offline_notified_at')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('device_presence_snoozes', function (Blueprint $table) {
+            $table->id();
+            $table->string('target_type', 16); // device | group
+            $table->unsignedBigInteger('target_id');
+            $table->timestamp('expires_at')->index();
+            $table->timestamps();
+
+            $table->unique(['target_type', 'target_id']);
+            $table->index(['target_type', 'target_id', 'expires_at']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('device_presence_snoozes');
+        Schema::dropIfExists('device_presence_notification_states');
+    }
+};

--- a/database/migrations/2026_08_21_000030_add_offline_claims_to_device_presence_notification_states.php
+++ b/database/migrations/2026_08_21_000030_add_offline_claims_to_device_presence_notification_states.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('device_presence_notification_states', function (Blueprint $table) {
+            $table->uuid('offline_claim_token')->nullable()->after('offline_notified_at');
+            $table->timestamp('offline_claimed_at')->nullable()->after('offline_claim_token');
+            $table->index('offline_claimed_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('device_presence_notification_states', function (Blueprint $table) {
+            $table->dropIndex(['offline_claimed_at']);
+            $table->dropColumn(['offline_claim_token', 'offline_claimed_at']);
+        });
+    }
+};

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true">
+    <testsuites>
+        <testsuite name="Feature">
+            <directory>tests/Feature</directory>
+        </testsuite>
+    </testsuites>
+    <source>
+        <include><directory suffix=".php">app</directory></include>
+    </source>
+    <php>
+        <env name="APP_ENV" value="testing"/>
+        <env name="APP_KEY" value="base64:MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI="/>
+        <env name="BCRYPT_ROUNDS" value="4"/>
+        <env name="CACHE_STORE" value="array"/>
+        <env name="DB_CONNECTION" value="sqlite"/>
+        <env name="DB_DATABASE" value=":memory:"/>
+        <env name="MAIL_MAILER" value="array"/>
+        <env name="QUEUE_CONNECTION" value="sync"/>
+        <env name="SESSION_DRIVER" value="array"/>
+    </php>
+</phpunit>

--- a/resources/views/livewire/settings-page.blade.php
+++ b/resources/views/livewire/settings-page.blade.php
@@ -674,8 +674,9 @@
                             </form>
                         </div>
                     </div>
-                    <div class="card">
-                        <div class="card-header"><h5 class="card-title mb-0">Presence alert maintenance</h5></div>
+                    @if (auth()->user()?->is_admin)
+                        <div class="card">
+                            <div class="card-header"><h5 class="card-title mb-0">Presence alert maintenance</h5></div>
                         <div class="card-body">
                             <p class="text-muted fs-13">Temporarily suppress offline and recovery notifications for one device or an entire group. Security and login alerts are not affected.</p>
                             <form wire:submit="createPresenceSnooze" class="row g-2 align-items-end">
@@ -694,7 +695,8 @@
                                 @endforelse
                             </div>
                         </div>
-                    </div>
+                        </div>
+                    @endif
                     <div class="card">
                         <div class="card-header"><h5 class="card-title mb-0">Recent deliveries</h5></div>
                         <div class="card-body">

--- a/resources/views/livewire/settings-page.blade.php
+++ b/resources/views/livewire/settings-page.blade.php
@@ -642,6 +642,7 @@
                                                        placeholder="{{ $appriseUrlsSet ? 'Stored — leave blank to keep' : 'One Apprise URL per line' }}"></textarea><div class="form-text">Write-only and encrypted at rest.</div></div>
                                 @endif
                                 <div class="mb-3"><label class="form-label">Cooldown (minutes)</label><input type="number" class="form-control" style="max-width: 140px" min="0" max="1440" wire:model="appriseCooldownMinutes"></div>
+                                <div class="mb-3"><label class="form-label">Offline alert grace (minutes)</label><input type="number" class="form-control @error('appriseOfflineGraceMinutes') is-invalid @enderror" style="max-width: 140px" min="0" max="1440" wire:model="appriseOfflineGraceMinutes"><div class="form-text">Wait this long after a device becomes offline before sending its Apprise alert.</div>@error('appriseOfflineGraceMinutes')<div class="invalid-feedback">{{ $message }}</div>@enderror</div>
                                 <div class="row">
                                     @foreach ($appriseEventLabels as $event => $label)
                                         @php $eventKey = str_replace('.', '_', $event); @endphp
@@ -671,6 +672,27 @@
                                 <button class="btn btn-outline-secondary mt-2" type="button" wire:click="sendTestNotification" @disabled(! $canManageSettings)>Send test</button>
                                 @if ($appriseTestMessage)<div class="alert {{ $appriseTestOk ? 'alert-success' : 'alert-danger' }} py-2 mt-3 mb-0">{{ $appriseTestMessage }}</div>@endif
                             </form>
+                        </div>
+                    </div>
+                    <div class="card">
+                        <div class="card-header"><h5 class="card-title mb-0">Presence alert maintenance</h5></div>
+                        <div class="card-body">
+                            <p class="text-muted fs-13">Temporarily suppress offline and recovery notifications for one device or an entire group. Security and login alerts are not affected.</p>
+                            <form wire:submit="createPresenceSnooze" class="row g-2 align-items-end">
+                                <div class="col-md-3"><label class="form-label">Apply to</label><select class="form-select" wire:model.live="presenceSnoozeTargetType"><option value="device">Device</option><option value="group">Device group</option></select></div>
+                                <div class="col-md-5"><label class="form-label">Target</label><select class="form-select @error('presenceSnoozeTargetId') is-invalid @enderror" wire:model="presenceSnoozeTargetId"><option value="0">Choose a target</option>@if($presenceSnoozeTargetType === 'group')@foreach($presenceSnoozeGroups as $group)<option value="{{ $group->id }}">{{ $group->name }}</option>@endforeach @else @foreach($presenceSnoozeDevices as $device)<option value="{{ $device->id }}">{{ $device->alias ?: ($device->hostname ?: $device->rustdesk_id) }}</option>@endforeach @endif</select></div>
+                                <div class="col-md-2"><label class="form-label">Minutes</label><input type="number" class="form-control @error('presenceSnoozeMinutes') is-invalid @enderror" min="15" max="10080" wire:model="presenceSnoozeMinutes"></div>
+                                <div class="col-md-2"><button class="btn btn-outline-warning w-100" type="submit" @disabled(! $canManageSettings)>Snooze alerts</button></div>
+                            </form>
+                            @error('presenceSnoozeTargetId')<div class="text-danger fs-13 mt-2">{{ $message }}</div>@enderror @error('presenceSnoozeMinutes')<div class="text-danger fs-13 mt-2">{{ $message }}</div>@enderror
+                            <div class="mt-3">
+                                @forelse($presenceSnoozes as $snooze)
+                                    @php $target = $snooze->target_type === 'group' ? $presenceSnoozeGroups->firstWhere('id', $snooze->target_id) : $presenceSnoozeDevices->firstWhere('id', $snooze->target_id); @endphp
+                                    <div class="d-flex justify-content-between align-items-center border-top py-2"><div><strong>{{ $snooze->target_type === 'group' ? 'Group' : 'Device' }}: {{ $target?->name ?: $target?->alias ?: $target?->hostname ?: $target?->rustdesk_id ?: 'Deleted target' }}</strong><div class="text-muted fs-13">Alerts muted until {{ $snooze->expires_at->toDayDateTimeString() }} ({{ $snooze->expires_at->diffForHumans() }})</div></div><button type="button" class="btn btn-sm btn-outline-secondary" wire:click="clearPresenceSnooze({{ $snooze->id }})" @disabled(! $canManageSettings)>End now</button></div>
+                                @empty
+                                    <div class="text-muted fs-13">No active presence-alert maintenance windows.</div>
+                                @endforelse
+                            </div>
                         </div>
                     </div>
                     <div class="card">

--- a/tests/Feature/DevicePresenceNotificationsTest.php
+++ b/tests/Feature/DevicePresenceNotificationsTest.php
@@ -5,6 +5,7 @@ use App\Models\Device;
 use App\Models\DeviceGroup;
 use App\Models\DevicePresenceNotificationState;
 use App\Models\DevicePresenceSnooze;
+use App\Models\Role;
 use App\Models\Setting;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -91,7 +92,19 @@ test('recovery is sent only for an outage whose offline delivery succeeded', fun
     expect(DevicePresenceNotificationState::query()->whereIn('device_id', [$delivered->id, $undelivered->id])->exists())->toBeFalse();
 });
 
-test('a settings administrator can create a bounded group maintenance snooze', function (): void {
+test('a recovery marker has exactly one atomic consumer', function (): void {
+    $device = presenceDevice();
+    DevicePresenceNotificationState::query()->create([
+        'device_id' => $device->id,
+        'offline_notified_at' => now(),
+    ]);
+
+    expect(DevicePresenceNotificationState::consumeFor($device))->toBeTrue()
+        ->and(DevicePresenceNotificationState::consumeFor($device))->toBeFalse()
+        ->and(DevicePresenceNotificationState::query()->where('device_id', $device->id)->exists())->toBeFalse();
+});
+
+test('an administrator can create a bounded group maintenance snooze', function (): void {
     Carbon::setTestNow('2026-08-21 12:00:00');
     $group = DeviceGroup::query()->create(['name' => 'Weekend work']);
     $admin = User::factory()->create(['is_admin' => true]);
@@ -109,4 +122,56 @@ test('a settings administrator can create a bounded group maintenance snooze', f
         'target_id' => $group->id,
         'expires_at' => now()->addMinutes(90),
     ]);
+});
+
+function delegatedSettingsManager(): User
+{
+    $role = Role::query()->create([
+        'name' => 'Settings manager',
+        'permissions' => ['setting' => 'rw'],
+    ]);
+
+    return User::factory()->create(['role_id' => $role->id]);
+}
+
+test('a delegated settings manager cannot create a presence snooze', function (): void {
+    $group = DeviceGroup::query()->create(['name' => 'Private maintenance']);
+    $manager = delegatedSettingsManager();
+
+    Livewire::actingAs($manager)
+        ->test(SettingsPage::class)
+        ->set('presenceSnoozeTargetType', 'group')
+        ->set('presenceSnoozeTargetId', $group->id)
+        ->call('createPresenceSnooze')
+        ->assertForbidden();
+
+    expect(DevicePresenceSnooze::query()->count())->toBe(0);
+});
+
+test('a delegated settings manager cannot end a presence snooze', function (): void {
+    $device = presenceDevice();
+    $snooze = DevicePresenceSnooze::snoozeDevice($device, now()->addHour());
+    $manager = delegatedSettingsManager();
+
+    Livewire::actingAs($manager)
+        ->test(SettingsPage::class)
+        ->call('clearPresenceSnooze', $snooze->id)
+        ->assertForbidden();
+
+    expect(DevicePresenceSnooze::query()->whereKey($snooze->id)->exists())->toBeTrue();
+});
+
+test('a delegated settings manager cannot see presence maintenance controls or targets', function (): void {
+    $group = DeviceGroup::query()->create(['name' => 'Secret fleet group']);
+    $device = presenceDevice(['hostname' => 'Secret fleet device']);
+    DevicePresenceSnooze::snoozeGroup($group, now()->addHour());
+    $manager = delegatedSettingsManager();
+
+    Livewire::actingAs($manager)
+        ->test(SettingsPage::class)
+        ->assertDontSee('Presence alert maintenance')
+        ->assertDontSee('Secret fleet group')
+        ->assertDontSee('Secret fleet device')
+        ->assertDontSee('Snooze alerts')
+        ->assertDontSee('End now');
 });

--- a/tests/Feature/DevicePresenceNotificationsTest.php
+++ b/tests/Feature/DevicePresenceNotificationsTest.php
@@ -10,7 +10,9 @@ use App\Models\Setting;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Crypt;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Http;
 use Livewire\Livewire;
 
@@ -102,6 +104,101 @@ test('a recovery marker has exactly one atomic consumer', function (): void {
     expect(DevicePresenceNotificationState::consumeFor($device))->toBeTrue()
         ->and(DevicePresenceNotificationState::consumeFor($device))->toBeFalse()
         ->and(DevicePresenceNotificationState::query()->where('device_id', $device->id)->exists())->toBeFalse();
+});
+
+test('only one contender can claim an offline delivery and only its token can mark it delivered', function (): void {
+    $device = presenceDevice();
+
+    $firstClaim = DevicePresenceNotificationState::claimOfflineFor($device);
+    $secondClaim = DevicePresenceNotificationState::claimOfflineFor($device);
+
+    expect($firstClaim)->toBeString()->not->toBe('')
+        ->and($secondClaim)->toBeNull()
+        ->and(DevicePresenceNotificationState::markDelivered($device, $firstClaim))->toBeTrue()
+        ->and(DevicePresenceNotificationState::query()->where('device_id', $device->id)->value('offline_notified_at'))->not->toBeNull();
+});
+
+test('a stale pending offline claim can be reclaimed but a fresh claim cannot', function (): void {
+    Carbon::setTestNow('2026-08-21 12:00:00');
+    $device = presenceDevice();
+    $staleToken = DevicePresenceNotificationState::claimOfflineFor($device);
+
+    expect(DevicePresenceNotificationState::claimOfflineFor($device))->toBeNull();
+
+    Carbon::setTestNow(now()->addSeconds(DevicePresenceNotificationState::CLAIM_TIMEOUT_SECONDS + 1));
+    $replacement = DevicePresenceNotificationState::claimOfflineFor($device);
+
+    expect($replacement)->toBeString()->not->toBe($staleToken)
+        ->and(DevicePresenceNotificationState::markDelivered($device, $staleToken))->toBeFalse()
+        ->and(DevicePresenceNotificationState::markDelivered($device, $replacement))->toBeTrue();
+});
+
+test('an offline device with a legacy cache marker is migrated without a duplicate offline alert', function (): void {
+    Carbon::setTestNow('2026-08-21 12:00:00');
+    $device = presenceDevice(['rustdesk_id' => 'legacy-offline']);
+    Cache::put('apprise:device-offline:'.sha1($device->rustdesk_id), true, now()->addDays(30));
+
+    $this->artisan('cortendesk:check-device-notifications')->assertSuccessful();
+
+    Http::assertNothingSent();
+    expect(DevicePresenceNotificationState::query()->where('device_id', $device->id)->value('offline_notified_at'))->not->toBeNull();
+});
+
+test('an online device atomically consumes a legacy marker and sends at most one recovery', function (): void {
+    Carbon::setTestNow('2026-08-21 12:00:00');
+    $device = presenceDevice(['rustdesk_id' => 'legacy-recovered', 'last_online_at' => now()]);
+    $key = 'apprise:device-offline:'.sha1($device->rustdesk_id);
+    Cache::put($key, true, now()->addDays(30));
+
+    $this->artisan('cortendesk:check-device-notifications')->assertSuccessful();
+    $this->artisan('cortendesk:check-device-notifications')->assertSuccessful();
+
+    Http::assertSentCount(1);
+    expect(Cache::has($key))->toBeFalse();
+});
+
+test('scheduled sweeps prune expired snoozes and aged orphaned targets', function (): void {
+    Carbon::setTestNow('2026-08-21 12:00:00');
+    $device = presenceDevice();
+    $expired = DevicePresenceSnooze::snoozeDevice($device, now()->subSecond());
+    $orphan = DevicePresenceSnooze::query()->create([
+        'target_type' => DevicePresenceSnooze::TARGET_DEVICE,
+        'target_id' => 999999,
+        'expires_at' => now()->addHour(),
+        'created_at' => now()->subDays(7)->subSecond(),
+        'updated_at' => now(),
+    ]);
+    DevicePresenceSnooze::query()->whereKey($orphan->id)->update(['created_at' => now()->subDays(7)->subSecond()]);
+
+    $this->artisan('cortendesk:check-device-notifications')->assertSuccessful();
+
+    expect(DevicePresenceSnooze::query()->whereKey($expired->id)->exists())->toBeFalse()
+        ->and(DevicePresenceSnooze::query()->whereKey($orphan->id)->exists())->toBeFalse();
+});
+
+test('only the owner of a pending claim can release it', function (): void {
+    $device = presenceDevice();
+    $claim = DevicePresenceNotificationState::claimOfflineFor($device);
+
+    expect(DevicePresenceNotificationState::releaseClaim($device, 'not-'.$claim))->toBeFalse()
+        ->and(DevicePresenceNotificationState::query()->where('device_id', $device->id)->exists())->toBeTrue()
+        ->and(DevicePresenceNotificationState::releaseClaim($device, $claim))->toBeTrue()
+        ->and(DevicePresenceNotificationState::query()->where('device_id', $device->id)->exists())->toBeFalse();
+});
+
+test('a sweep preloads snoozes and notification state instead of querying them per device', function (): void {
+    Carbon::setTestNow('2026-08-21 12:00:00');
+    presenceDevice(['rustdesk_id' => 'batch-one']);
+    presenceDevice(['rustdesk_id' => 'batch-two']);
+    $queries = [];
+    DB::listen(function ($query) use (&$queries): void {
+        $queries[] = $query->sql;
+    });
+
+    $this->artisan('cortendesk:check-device-notifications')->assertSuccessful();
+
+    expect(collect($queries)->filter(fn (string $sql) => str_starts_with(strtolower($sql), 'select') && str_contains($sql, 'device_presence_notification_states'))->count())->toBeLessThanOrEqual(1)
+        ->and(collect($queries)->filter(fn (string $sql) => str_starts_with(strtolower($sql), 'select') && str_contains($sql, 'device_presence_snoozes'))->count())->toBeLessThanOrEqual(1);
 });
 
 test('an administrator can create a bounded group maintenance snooze', function (): void {

--- a/tests/Feature/DevicePresenceNotificationsTest.php
+++ b/tests/Feature/DevicePresenceNotificationsTest.php
@@ -1,0 +1,112 @@
+<?php
+
+use App\Livewire\SettingsPage;
+use App\Models\Device;
+use App\Models\DeviceGroup;
+use App\Models\DevicePresenceNotificationState;
+use App\Models\DevicePresenceSnooze;
+use App\Models\Setting;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Crypt;
+use Illuminate\Support\Facades\Http;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function (): void {
+    Setting::put('online_window', '60');
+    Setting::put('apprise_offline_grace_minutes', '10');
+    Setting::put('apprise_enabled', '1');
+    Setting::put('apprise_event_device_offline', '1');
+    Setting::put('apprise_event_device_online', '1');
+    Setting::put('apprise_delivery_mode', 'config');
+    Setting::put('apprise_endpoint', Crypt::encryptString('https://apprise.test'));
+    Setting::put('apprise_config_key', Crypt::encryptString('alerts'));
+    Setting::put('apprise_cooldown_minutes', '0');
+
+    Http::fake(['https://apprise.test/notify/alerts' => Http::response([], 200)]);
+});
+
+function presenceDevice(array $attributes = []): Device
+{
+    return Device::query()->create(array_merge([
+        'rustdesk_id' => 'device-'.uniqid(),
+        'uuid' => 'uuid-'.uniqid(),
+        'status' => Device::STATUS_ACTIVE,
+        'hostname' => 'Test device',
+        'last_online_at' => now()->subMinutes(11),
+    ], $attributes));
+}
+
+test('offline delivery waits for the configured grace period before recording the outage', function (): void {
+    Carbon::setTestNow('2026-08-21 12:00:00');
+    $device = presenceDevice(['last_online_at' => now()->subMinutes(9)->subSeconds(60)]);
+
+    $this->artisan('cortendesk:check-device-notifications')->assertSuccessful();
+
+    Http::assertNothingSent();
+    expect(DevicePresenceNotificationState::query()->where('device_id', $device->id)->exists())->toBeFalse();
+
+    Carbon::setTestNow(now()->addMinutes(2));
+    $this->artisan('cortendesk:check-device-notifications')->assertSuccessful();
+
+    Http::assertSentCount(1);
+    expect(DevicePresenceNotificationState::query()->where('device_id', $device->id)->value('offline_notified_at'))->not->toBeNull();
+});
+
+test('an active group snooze suppresses presence notifications and expires at its configured time', function (): void {
+    Carbon::setTestNow('2026-08-21 12:00:00');
+    $group = DeviceGroup::query()->create(['name' => 'Planned maintenance']);
+    $device = presenceDevice(['device_group_id' => $group->id]);
+
+    DevicePresenceSnooze::snoozeGroup($group, now()->addHours(2));
+    $this->artisan('cortendesk:check-device-notifications')->assertSuccessful();
+
+    Http::assertNothingSent();
+    expect(DevicePresenceNotificationState::query()->where('device_id', $device->id)->exists())->toBeFalse();
+
+    Carbon::setTestNow(now()->addHours(2)->addSecond());
+    $this->artisan('cortendesk:check-device-notifications')->assertSuccessful();
+
+    Http::assertSentCount(1);
+});
+
+test('recovery is sent only for an outage whose offline delivery succeeded', function (): void {
+    Carbon::setTestNow('2026-08-21 12:00:00');
+    $delivered = presenceDevice(['rustdesk_id' => 'delivered-outage']);
+    $undelivered = presenceDevice(['rustdesk_id' => 'undelivered-outage']);
+
+    $this->artisan('cortendesk:check-device-notifications')->assertSuccessful();
+    expect(DevicePresenceNotificationState::query()->where('device_id', $delivered->id)->value('offline_notified_at'))->not->toBeNull();
+
+    DevicePresenceNotificationState::query()->where('device_id', $undelivered->id)->delete();
+    $delivered->update(['last_online_at' => now()]);
+    $undelivered->update(['last_online_at' => now()]);
+
+    $this->artisan('cortendesk:check-device-notifications')->assertSuccessful();
+
+    Http::assertSentCount(3);
+    expect(DevicePresenceNotificationState::query()->whereIn('device_id', [$delivered->id, $undelivered->id])->exists())->toBeFalse();
+});
+
+test('a settings administrator can create a bounded group maintenance snooze', function (): void {
+    Carbon::setTestNow('2026-08-21 12:00:00');
+    $group = DeviceGroup::query()->create(['name' => 'Weekend work']);
+    $admin = User::factory()->create(['is_admin' => true]);
+
+    Livewire::actingAs($admin)
+        ->test(SettingsPage::class)
+        ->set('presenceSnoozeTargetType', 'group')
+        ->set('presenceSnoozeTargetId', $group->id)
+        ->set('presenceSnoozeMinutes', 90)
+        ->call('createPresenceSnooze')
+        ->assertHasNoErrors();
+
+    $this->assertDatabaseHas('device_presence_snoozes', [
+        'target_type' => 'group',
+        'target_id' => $group->id,
+        'expires_at' => now()->addMinutes(90),
+    ]);
+});

--- a/tests/Feature/DevicePresenceNotificationsTest.php
+++ b/tests/Feature/DevicePresenceNotificationsTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Console\Commands\CheckDeviceNotifications;
 use App\Livewire\SettingsPage;
 use App\Models\Device;
 use App\Models\DeviceGroup;
@@ -8,6 +9,7 @@ use App\Models\DevicePresenceSnooze;
 use App\Models\Role;
 use App\Models\Setting;
 use App\Models\User;
+use App\Services\AppriseNotifications;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Cache;
@@ -155,6 +157,64 @@ test('an online device atomically consumes a legacy marker and sends at most one
 
     Http::assertSentCount(1);
     expect(Cache::has($key))->toBeFalse();
+});
+
+test('a stale legacy marker paired with delivered state cannot send a second recovery', function (): void {
+    Carbon::setTestNow('2026-08-21 12:00:00');
+    $device = presenceDevice(['rustdesk_id' => 'legacy-and-durable-recovered', 'last_online_at' => now()]);
+    $key = 'apprise:device-offline:'.sha1($device->rustdesk_id);
+    DevicePresenceNotificationState::recordLegacyOffline($device);
+    Cache::put($key, true, now()->addDays(30));
+
+    $this->artisan('cortendesk:check-device-notifications')->assertSuccessful();
+    $this->artisan('cortendesk:check-device-notifications')->assertSuccessful();
+
+    Http::assertSentCount(1);
+    expect(Cache::has($key))->toBeFalse()
+        ->and(DevicePresenceNotificationState::query()->where('device_id', $device->id)->exists())->toBeFalse();
+});
+
+test('a legacy marker claim makes a concurrent recovery lose without resurrecting durable state', function (): void {
+    Carbon::setTestNow('2026-08-21 12:00:00');
+    $device = presenceDevice(['rustdesk_id' => 'legacy-offline-online-race']);
+    $key = 'apprise:device-offline:'.sha1($device->rustdesk_id);
+    Cache::put($key, true, now()->addDays(30));
+
+    $sweepClaim = DevicePresenceNotificationState::claimLegacyMarkerFor($device);
+
+    expect($sweepClaim)->toBeString()->not->toBe('')
+        ->and(DevicePresenceNotificationState::claimLegacyMarkerFor($device))->toBeNull();
+
+    // The online heartbeat loses the sweep's shared claim and must not send a
+    // recovery. The competing sweep also cannot resurrect a durable marker.
+    CheckDeviceNotifications::reportOnline($device, app(AppriseNotifications::class));
+    Http::assertNothingSent();
+
+    $this->artisan('cortendesk:check-device-notifications')->assertSuccessful();
+
+    expect(DevicePresenceNotificationState::query()->where('device_id', $device->id)->exists())->toBeFalse()
+        ->and(DevicePresenceNotificationState::convertClaimedLegacyMarkerFor($device, $sweepClaim))->toBeTrue();
+
+    expect(Cache::has($key))->toBeFalse()
+        ->and(DevicePresenceNotificationState::query()->where('device_id', $device->id)->value('offline_notified_at'))->not->toBeNull()
+        ->and(DevicePresenceNotificationState::claimLegacyMarkerFor($device))->toBeFalse()
+        ->and(DevicePresenceNotificationState::consumeFor($device))->toBeTrue()
+        ->and(DevicePresenceNotificationState::query()->where('device_id', $device->id)->exists())->toBeFalse();
+});
+
+test('an expired legacy claim can be recovered only by its replacement token', function (): void {
+    Carbon::setTestNow('2026-08-21 12:00:00');
+    $device = presenceDevice(['rustdesk_id' => 'legacy-claim-expiry']);
+    Cache::put('apprise:device-offline:'.sha1($device->rustdesk_id), true, now()->addDays(30));
+
+    $expired = DevicePresenceNotificationState::claimLegacyMarkerFor($device);
+    Carbon::setTestNow(now()->addSeconds(DevicePresenceNotificationState::CLAIM_TIMEOUT_SECONDS + 1));
+    $replacement = DevicePresenceNotificationState::claimLegacyMarkerFor($device);
+
+    expect($expired)->toBeString()
+        ->and($replacement)->toBeString()->not->toBe($expired)
+        ->and(DevicePresenceNotificationState::consumeClaimedLegacyMarkerFor($device, $expired))->toBeFalse()
+        ->and(DevicePresenceNotificationState::consumeClaimedLegacyMarkerFor($device, $replacement))->toBeTrue();
 });
 
 test('scheduled sweeps prune expired snoozes and aged orphaned targets', function (): void {

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,0 +1,5 @@
+<?php
+
+use Tests\TestCase;
+
+uses(TestCase::class)->in('Feature');

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Tests;
+
+use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
+
+abstract class TestCase extends BaseTestCase
+{
+    // Laravel's base test case discovers bootstrap/app.php automatically.
+}


### PR DESCRIPTION
## Summary

- add a configurable **0–1440 minute** offline-alert grace period
- add admin-only device/group presence-maintenance snoozes for **15 minutes–7 days**
- show active snooze targets and expiry with an explicit **End now** action
- persist successful offline-delivery state so recovery notifications survive cache/process restarts
- batch presence-state/snooze loading and prune expired or aged orphan snoozes

## Delivery correctness

- snoozes affect only `device.offline` and `device.online`; security/login events are unchanged
- recovery is possible only after a successfully recorded offline delivery
- durable token-owned claims prevent concurrent duplicate offline sends
- recovery markers are consumed atomically for at-most-once recovery handling
- stale claims can be reclaimed after five minutes
- legacy 30-day cache markers remain compatible without duplicate offline/recovery events
- the legacy conversion and heartbeat paths share an atomic per-device claim

## Authorization

- snooze controls and target data are visible only to administrators
- create/end mutations independently fail closed for non-admin users
- normal offline-grace configuration retains existing settings permissions

## Verification

- `php artisan test` — **18 passed, 81 assertions**
- fresh SQLite migrations and migration status — passed
- scoped Pint and Blade view cache — passed
- `git diff --check` — passed
- final independent spec and code-quality review — approved

Closes #49
