### PR TITLE
fix: protect dashboard audit data from restricted roles

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -18,10 +18,13 @@ class DashboardController extends Controller
     public function index(Request $request): View
     {
         $user = $request->user();
+        $canAudit = $user->consoleAllows('audit', 'r');
 
         // Non-admins: everything on the dashboard is scoped to the devices
-        // they can see. Admins: null = no scope (whole fleet).
-        $visibleIds = $user->seesAllDevices()
+        // they can see. Admins: null = no scope (whole fleet). Do not resolve
+        // audit scope at all when the role cannot view logs: even aggregate
+        // connection activity is part of the gated Logs area.
+        $visibleIds = ! $canAudit || $user->seesAllDevices()
             ? null
             : Device::query()->visibleTo($user)->pluck('rustdesk_id')->all();
 
@@ -35,12 +38,12 @@ class DashboardController extends Controller
         return view('overview', [
             'range' => $range,
             'ranges' => self::RANGES,
-            'connectionSeries' => $this->connectionSeries($visibleIds, $range),
+            'connectionSeries' => $canAudit ? $this->connectionSeries($visibleIds, $range) : null,
             'platformMix' => $this->platformMix($user),
             'versionCounts' => $this->versionCounts($user),
             // Alarm detail is an audit screen; the count tile is fleet-level but
             // the rows name devices, so this panel is gated. null = not allowed.
-            'recentAlarms' => $user->consoleAllows('audit', 'r')
+            'recentAlarms' => $canAudit
                 ? $this->recentAlarms($visibleIds)
                 : null,
         ]);

--- a/app/Livewire/ActiveSessions.php
+++ b/app/Livewire/ActiveSessions.php
@@ -2,6 +2,7 @@
 
 namespace App\Livewire;
 
+use App\Livewire\Concerns\AuthorizesConsole;
 use App\Models\AuditConnection;
 use App\Models\ConsoleAudit;
 use App\Models\Device;
@@ -9,6 +10,13 @@ use Livewire\Component;
 
 class ActiveSessions extends Component
 {
+    use AuthorizesConsole;
+
+    public function mount(): void
+    {
+        $this->authorizeConsole('audit', 'r');
+    }
+
     /**
      * Ask the controlled device to close a live session.
      *
@@ -20,6 +28,7 @@ class ActiveSessions extends Component
      */
     public function disconnect(int $id): void
     {
+        $this->authorizeConsole('audit', 'r');
         $user = auth()->user();
 
         $session = AuditConnection::query()
@@ -58,6 +67,9 @@ class ActiveSessions extends Component
 
     public function render()
     {
+        // Polls and Livewire updates are separate requests. Re-check so a role
+        // losing Logs access stops receiving session data immediately.
+        $this->authorizeConsole('audit', 'r');
         $user = auth()->user();
         $visibleIds = $user->seesAllDevices()
             ? null

--- a/app/Livewire/LiveStats.php
+++ b/app/Livewire/LiveStats.php
@@ -15,8 +15,11 @@ class LiveStats extends Component
     {
         $user = auth()->user();
         $admin = $user->seesAllDevices();
+        $canAudit = $user->consoleAllows('audit', 'r');
 
-        $visibleIds = $admin ? null : Device::query()->visibleTo($user)->pluck('rustdesk_id')->all();
+        $visibleIds = ! $canAudit || $admin
+            ? null
+            : Device::query()->visibleTo($user)->pluck('rustdesk_id')->all();
 
         $devices = Device::query()->visibleTo($user)->count();
         $online = Device::query()->visibleTo($user)->online()->count();
@@ -33,26 +36,29 @@ class LiveStats extends Component
         $connections = fn () => AuditConnection::query()
             ->when($visibleIds !== null, fn ($q) => $q->whereIn('rustdesk_id', $visibleIds));
 
-        $connectionsToday = $connections()->whereDate('created_at', today())->count();
-        $connectionsYesterday = $connections()->whereDate('created_at', today()->subDay())->count();
+        $connectionsToday = $canAudit ? $connections()->whereDate('created_at', today())->count() : null;
+        $connectionsYesterday = $canAudit ? $connections()->whereDate('created_at', today()->subDay())->count() : null;
 
         // Deliberately the same predicate as App\Livewire\ActiveSessions, so the
         // tile and the table underneath it can never disagree.
-        $sessions = $connections()
-            ->whereNull('closed_at')
-            ->whereNotNull('from_peer')
-            ->where('from_peer', '!=', '')
-            ->where('created_at', '>=', now()->subDay())
-            ->count();
+        $sessions = $canAudit
+            ? $connections()
+                ->whereNull('closed_at')
+                ->whereNotNull('from_peer')
+                ->where('from_peer', '!=', '')
+                ->where('created_at', '>=', now()->subDay())
+                ->count()
+            : null;
 
         $alarms = fn () => AlarmLog::query()
             ->when($visibleIds !== null, fn ($q) => $q->whereIn('rustdesk_id', $visibleIds))
             ->where('created_at', '>=', now()->subDay());
 
-        $alarms24h = $alarms()->count();
+        $alarms24h = $canAudit ? $alarms()->count() : null;
 
         return view('livewire.live-stats', [
             'admin' => $admin,
+            'canAudit' => $canAudit,
             'devices' => $devices,
             'online' => $online,
             'onlinePct' => $devices > 0 ? (int) round($online / $devices * 100) : null,
@@ -69,10 +75,10 @@ class LiveStats extends Component
                     ->count('user_id')
                 : null,
             'connectionsToday' => $connectionsToday,
-            'connectionTrend' => $connectionsToday - $connectionsYesterday,
+            'connectionTrend' => $canAudit ? $connectionsToday - $connectionsYesterday : null,
             'sessions' => $sessions,
             'alarms24h' => $alarms24h,
-            'lastAlarmAt' => $alarms24h > 0 ? $alarms()->latest('id')->value('created_at') : null,
+            'lastAlarmAt' => $canAudit && $alarms24h > 0 ? $alarms()->latest('id')->value('created_at') : null,
         ]);
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true">
+    <testsuites>
+        <testsuite name="Feature">
+            <directory>tests/Feature</directory>
+        </testsuite>
+    </testsuites>
+    <source>
+        <include>
+            <directory>app</directory>
+        </include>
+    </source>
+    <php>
+        <env name="APP_ENV" value="testing"/>
+        <env name="APP_MAINTENANCE_DRIVER" value="file"/>
+        <!-- Fixed public test-only key; never use outside the test environment. -->
+        <env name="APP_KEY" value="base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="/>
+        <env name="APP_URL" value="http://localhost"/>
+        <env name="BCRYPT_ROUNDS" value="4"/>
+        <env name="BROADCAST_CONNECTION" value="null"/>
+        <env name="CACHE_STORE" value="array"/>
+        <env name="DB_CONNECTION" value="sqlite"/>
+        <env name="DB_DATABASE" value=":memory:"/>
+        <env name="DB_URL" value=""/>
+        <env name="MAIL_MAILER" value="array"/>
+        <env name="QUEUE_CONNECTION" value="sync"/>
+        <env name="SESSION_DRIVER" value="array"/>
+    </php>
+</phpunit>

--- a/resources/views/livewire/live-stats.blade.php
+++ b/resources/views/livewire/live-stats.blade.php
@@ -66,6 +66,8 @@
         </a>
     @endif
 
+    @if ($canAudit)
+    {{-- Audit-derived tiles ------------------------------------------------- --}}
     {{-- Active sessions ----------------------------------------------------- --}}
     <a href="{{ route('logs.connections') }}" class="card text-reset card-hover" title="View connection log">
         <div class="card-body">
@@ -137,4 +139,5 @@
             </div>
         </div>
     </a>
+    @endif
 </div>

--- a/resources/views/overview.blade.php
+++ b/resources/views/overview.blade.php
@@ -27,6 +27,7 @@
     @livewire(App\Livewire\LiveStats::class)
 
     <div class="row rd-row-equal">
+        @if ($connectionSeries !== null)
         <div class="col-xl-8">
             <div class="card">
                 <div class="card-header d-flex flex-wrap align-items-center gap-2">
@@ -50,8 +51,9 @@
                 </div>
             </div>
         </div>
+        @endif
 
-        <div class="col-xl-4">
+        <div class="{{ $connectionSeries !== null ? 'col-xl-4' : 'col-12' }}">
             @php
                 $platformTotal = array_sum($platformMix['values']);
                 // Same order as the chart series palette in the script below.
@@ -94,17 +96,19 @@
     </div>
 
     @php
-        // Alerts is permission-gated (the controller nulls it without audit
-        // read), so the remaining two cards have to widen to keep the row at
-        // twelve columns — an equal-height row is not an equal-WIDTH one.
+        // Every audit-derived panel is permission-gated. The remaining fleet
+        // card widens when Logs access is absent.
+        $hasAudit = $connectionSeries !== null;
         $hasAlerts = $recentAlarms !== null;
     @endphp
     <div class="row rd-row-equal">
+        @if ($hasAudit)
         <div class="{{ $hasAlerts ? 'col-xl-5' : 'col-xl-7' }}">
             @livewire(App\Livewire\ActiveSessions::class)
         </div>
+        @endif
 
-        <div class="{{ $hasAlerts ? 'col-xl-4' : 'col-xl-5' }}">
+        <div class="{{ ! $hasAudit ? 'col-12' : ($hasAlerts ? 'col-xl-4' : 'col-xl-5') }}">
             @php
                 $versionTotal = array_sum($versionCounts['values']);
                 $versionMax = $versionCounts['values'] ? max($versionCounts['values']) : 0;
@@ -245,36 +249,38 @@
         charts = [];
         var t = theme();
 
-        // Daily connections, stacked by type. Bars thin out as the range grows
-        // so 90 days stays readable; a hairline gap separates the segments.
-        var days = connectionData.labels.length;
-        var connEl = document.querySelector("#chart-connections");
-        // Date labels need ~62px each. Ask for only as many ticks as the card
-        // is actually wide enough for, or 90 days collides into a smear.
-        var ticks = Math.max(3, Math.floor((connEl.clientWidth || 600) / 62));
+        if (connectionData) {
+            // Daily connections, stacked by type. Bars thin out as the range
+            // grows so 90 days stays readable; a hairline gap separates them.
+            var days = connectionData.labels.length;
+            var connEl = document.querySelector("#chart-connections");
+            // Date labels need ~62px each. Ask for only as many ticks as the
+            // card is actually wide enough for.
+            var ticks = Math.max(3, Math.floor((connEl.clientWidth || 600) / 62));
 
-        var conn = new ApexCharts(connEl, Object.assign(baseOptions(t), {
-            chart: Object.assign(baseOptions(t).chart, { type: "bar", height: 300, stacked: true }),
-            series: connectionData.series,
-            colors: t.series.slice(0, 3),
-            plotOptions: { bar: {
-                columnWidth: days > 60 ? "80%" : (days > 20 ? "62%" : "45%"),
-                borderRadius: 3,
-                borderRadiusApplication: "end",
-                borderRadiusWhenStacked: "last"
-            } },
-            stroke: { show: true, width: 2, colors: [t.surface] },
-            xaxis: {
-                categories: connectionData.labels,
-                tickAmount: Math.min(days, ticks),
-                axisBorder: { color: t.grid },
-                axisTicks: { show: false },
-                labels: { rotate: 0, hideOverlappingLabels: true }
-            },
-            yaxis: { labels: { formatter: function (v) { return Math.round(v); } } },
-            legend: Object.assign(baseOptions(t).legend, { position: "bottom", horizontalAlign: "left", offsetY: 4 })
-        }));
-        charts.push(conn);
+            var conn = new ApexCharts(connEl, Object.assign(baseOptions(t), {
+                chart: Object.assign(baseOptions(t).chart, { type: "bar", height: 300, stacked: true }),
+                series: connectionData.series,
+                colors: t.series.slice(0, 3),
+                plotOptions: { bar: {
+                    columnWidth: days > 60 ? "80%" : (days > 20 ? "62%" : "45%"),
+                    borderRadius: 3,
+                    borderRadiusApplication: "end",
+                    borderRadiusWhenStacked: "last"
+                } },
+                stroke: { show: true, width: 2, colors: [t.surface] },
+                xaxis: {
+                    categories: connectionData.labels,
+                    tickAmount: Math.min(days, ticks),
+                    axisBorder: { color: t.grid },
+                    axisTicks: { show: false },
+                    labels: { rotate: 0, hideOverlappingLabels: true }
+                },
+                yaxis: { labels: { formatter: function (v) { return Math.round(v); } } },
+                legend: Object.assign(baseOptions(t).legend, { position: "bottom", horizontalAlign: "left", offsetY: 4 })
+            }));
+            charts.push(conn);
+        }
 
         // Platform donut: wide hole carrying the total; identity is carried by
         // the .rd-legend list beside it, so Apex's own legend stays off.

--- a/tests/Feature/DashboardAuditPermissionTest.php
+++ b/tests/Feature/DashboardAuditPermissionTest.php
@@ -1,0 +1,109 @@
+<?php
+
+use App\Livewire\ActiveSessions;
+use App\Livewire\LiveStats;
+use App\Models\AlarmLog;
+use App\Models\AuditConnection;
+use App\Models\Device;
+use App\Models\Role;
+use App\Models\User;
+use App\Support\Permissions;
+use Illuminate\Support\Facades\DB;
+use Livewire\Livewire;
+
+function dashboardUserWithAuditLevel(string $level): User
+{
+    $role = Role::create([
+        'name' => 'Dashboard '.$level.' '.fake()->unique()->word(),
+        'permissions' => Role::normalizePermissions([
+            'device' => 'r',
+            'audit' => $level,
+        ]),
+    ]);
+
+    return User::factory()->create(['role_id' => $role->id]);
+}
+
+function dashboardAuditFixture(User $user): void
+{
+    Device::create([
+        'rustdesk_id' => '900001',
+        'uuid' => 'dashboard-audit-device',
+        'status' => Device::STATUS_ACTIVE,
+        'user_id' => $user->id,
+        'last_online_at' => now(),
+    ]);
+
+    AuditConnection::create([
+        'action' => 'new',
+        'conn_id' => 1234,
+        'rustdesk_id' => '900001',
+        'from_peer' => 'sensitive-controller-id',
+        'from_name' => 'Sensitive Operator',
+        'conn_type' => 0,
+    ]);
+
+    AlarmLog::create([
+        'rustdesk_id' => '900001',
+        'typ' => 9,
+        'info' => json_encode(['detail' => 'sensitive alarm detail']),
+    ]);
+}
+
+test('the overview does not disclose audit activity to a role without log access', function () {
+    $user = dashboardUserWithAuditLevel('none');
+    dashboardAuditFixture($user);
+    $queries = [];
+    DB::listen(function ($query) use (&$queries): void {
+        $queries[] = $query->sql;
+    });
+
+    $this->actingAs($user)
+        ->get(route('overview'))
+        ->assertOk()
+        ->assertSee('Devices')
+        ->assertDontSee('Sensitive Operator')
+        ->assertDontSee('Active Sessions')
+        ->assertDontSee('Connections started today')
+        ->assertDontSee('Alarms (24h)');
+
+    expect(collect($queries)->filter(fn (string $sql) => str_contains($sql, 'audit_connections')
+        || str_contains($sql, 'alarm_logs')))->toBeEmpty();
+});
+
+test('live dashboard stats omit audit tiles for a role without log access', function () {
+    $user = dashboardUserWithAuditLevel('none');
+    dashboardAuditFixture($user);
+
+    Livewire::actingAs($user)
+        ->test(LiveStats::class)
+        ->assertSee('Devices')
+        ->assertDontSee('Sessions')
+        ->assertDontSee('Connections')
+        ->assertDontSee('Alarms (24h)');
+});
+
+test('the active sessions component rejects direct access without log permission', function () {
+    $user = dashboardUserWithAuditLevel('none');
+    dashboardAuditFixture($user);
+
+    Livewire::actingAs($user)
+        ->test(ActiveSessions::class)
+        ->assertForbidden();
+});
+
+test('a role with audit view still receives the dashboard audit surfaces', function () {
+    $user = dashboardUserWithAuditLevel('r');
+    dashboardAuditFixture($user);
+
+    expect($user->consoleAllows('audit', 'r'))->toBeTrue()
+        ->and(Permissions::satisfies('r', 'r'))->toBeTrue();
+
+    $this->actingAs($user)
+        ->get(route('overview'))
+        ->assertOk()
+        ->assertSee('Sensitive Operator')
+        ->assertSee('Active Sessions')
+        ->assertSee('Connections started today')
+        ->assertSee('Alarms (24h)');
+});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,0 +1,8 @@
+<?php
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+pest()->extend(TestCase::class)
+    ->use(RefreshDatabase::class)
+    ->in('Feature');

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Tests;
+
+use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
+
+abstract class TestCase extends BaseTestCase
+{
+    //
+}


### PR DESCRIPTION
## Summary
- enforce the delegated `audit:r` permission across every audit-derived Overview surface
- stop rendering or querying connection, active-session, and alarm data for roles without Logs access
- re-check `ActiveSessions` authorization on mount, polls/renders, and disconnect actions so revoked access fails closed
- preserve device/platform/version cards for restricted roles and the existing full dashboard for authorized users

## Root cause
The log routes were permission-gated, but the Overview controller and polling Livewire components queried and rendered the same audit data independently. A delegated role with `audit: none` could therefore see connection aggregates, alarm counts, and active-session peer details from the Overview page or by mounting the component directly.

## Verification
- canonical `composer test`: **4 tests, 19 assertions passed**
- regression test was observed failing before the fix (3 of 4 cases failed for the expected permission leak)
- focused/full public-tree suite: **4 tests, 19 assertions passed**
- Pint passed on all changed PHP and test files
- Laravel config, route, and Blade cache compilation passed
- authenticated HTTP smoke path verified both sides:
  - `audit: none`: fleet cards remain, audit queries/data/tiles are absent
  - `audit: r`: connection chart, active sessions, and alarm tile remain visible
- rendered authorized and restricted inline dashboard scripts both pass `node --check`

No dependency or schema changes.
