### PR TITLE
fix: enforce delegated address-book read-only roles

### DIFF
--- a/app/Livewire/AddressBookManager.php
+++ b/app/Livewire/AddressBookManager.php
@@ -516,7 +516,7 @@ class AddressBookManager extends Component
     {
         $book = $this->book();
 
-        if (! $book || $book->permissionFor(auth()->user()) < $required) {
+        if (! $book || $this->permission() < $required) {
             return null;
         }
 
@@ -566,7 +566,7 @@ class AddressBookManager extends Component
 
         // Effective tier of the current user on the selected book (PLAN B4) —
         // drives which action buttons render.
-        $permission = $book ? $book->permissionFor(auth()->user()) : 0;
+        $permission = $this->permission();
 
         return view('livewire.address-book-manager', [
             'books' => $books,

--- a/app/Livewire/DeviceList.php
+++ b/app/Livewire/DeviceList.php
@@ -345,6 +345,8 @@ class DeviceList extends Component
 
     public function openAbPicker(): void
     {
+        $this->authorizeConsole('address_book', 'rw');
+
         if ($this->selected === []) {
             return;
         }
@@ -364,6 +366,8 @@ class DeviceList extends Component
 
     public function addSelectedToBook(): void
     {
+        $this->authorizeConsole('address_book', 'rw');
+
         $book = $this->writableBooks()->firstWhere('id', $this->abBookId);
         if (! $book) {
             $this->addError('abBookId', 'Pick an address book.');
@@ -419,6 +423,10 @@ class DeviceList extends Component
     private function writableBooks()
     {
         $user = auth()->user();
+
+        if (! $this->consoleAllows('address_book', 'rw')) {
+            return collect();
+        }
 
         return AddressBook::query()
             ->with('rules')

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true">
+    <testsuites>
+        <testsuite name="Feature">
+            <directory>tests/Feature</directory>
+        </testsuite>
+    </testsuites>
+    <source>
+        <include>
+            <directory>app</directory>
+        </include>
+    </source>
+    <php>
+        <env name="APP_ENV" value="testing"/>
+        <env name="APP_MAINTENANCE_DRIVER" value="file"/>
+        <!-- Fixed public test-only key; never use outside the test environment. -->
+        <env name="APP_KEY" value="base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="/>
+        <env name="APP_URL" value="http://localhost"/>
+        <env name="BCRYPT_ROUNDS" value="4"/>
+        <env name="BROADCAST_CONNECTION" value="null"/>
+        <env name="CACHE_STORE" value="array"/>
+        <env name="DB_CONNECTION" value="sqlite"/>
+        <env name="DB_DATABASE" value=":memory:"/>
+        <env name="DB_URL" value=""/>
+        <env name="MAIL_MAILER" value="array"/>
+        <env name="QUEUE_CONNECTION" value="sync"/>
+        <env name="SESSION_DRIVER" value="array"/>
+    </php>
+</phpunit>

--- a/resources/views/livewire/device-list.blade.php
+++ b/resources/views/livewire/device-list.blade.php
@@ -156,9 +156,11 @@
             <div class="rd-toolbar d-none d-md-flex">
                 @if ($selected !== [])
                     <span class="fs-13 fw-semibold">{{ count($selected) }} selected</span>
-                    <button type="button" class="btn btn-sm btn-light" wire:click="openAbPicker">
-                        <i class="ri-contacts-book-2-line me-1"></i>Add to Address Book…
-                    </button>
+                    @if (auth()->user()?->consoleAllows('address_book', 'rw'))
+                        <button type="button" class="btn btn-sm btn-light" wire:click="openAbPicker">
+                            <i class="ri-contacts-book-2-line me-1"></i>Add to Address Book…
+                        </button>
+                    @endif
                     @if (auth()->user()?->consoleAllows('device', 'rw'))
                         <button type="button" class="btn btn-sm btn-outline-danger" wire:click="bulkDelete"
                                 wire:confirm="Move {{ count($selected) }} selected device(s) to the recycle bin?">

--- a/tests/Feature/AddressBookReadonlyPermissionTest.php
+++ b/tests/Feature/AddressBookReadonlyPermissionTest.php
@@ -1,0 +1,142 @@
+<?php
+
+use App\Livewire\AddressBookManager;
+use App\Livewire\DeviceList;
+use App\Models\AddressBook;
+use App\Models\AddressBookEntry;
+use App\Models\AddressBookRule;
+use App\Models\Device;
+use App\Models\Role;
+use App\Models\User;
+use Livewire\Livewire;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+function addressBookUserWithConsoleLevel(string $level): User
+{
+    $role = Role::create([
+        'name' => 'Address book '.$level.' '.fake()->unique()->word(),
+        'permissions' => Role::normalizePermissions([
+            'address_book' => $level,
+            'device' => 'rw',
+        ]),
+    ]);
+
+    return User::factory()->create(['role_id' => $role->id]);
+}
+
+test('a delegated address book viewer cannot add entries to an owned personal book', function () {
+    $user = addressBookUserWithConsoleLevel('r');
+    $book = AddressBook::personalFor($user);
+
+    Livewire::actingAs($user)
+        ->test(AddressBookManager::class)
+        ->set('selectedBookId', $book->id)
+        ->set('entryRustdeskId', 'readonly-denied-peer')
+        ->set('entryAlias', 'Must not be created')
+        ->call('saveEntry');
+
+    expect(AddressBookEntry::where('address_book_id', $book->id)->count())->toBe(0);
+});
+
+test('an owned shared book renders read only for a delegated address book viewer', function () {
+    $user = addressBookUserWithConsoleLevel('r');
+    $book = AddressBook::create([
+        'name' => 'Viewer-owned shared book',
+        'owner_user_id' => $user->id,
+        'is_personal' => false,
+    ]);
+
+    $this->actingAs($user);
+    $component = app(AddressBookManager::class);
+    $component->mount();
+    $component->selectedBookId = $book->id;
+    $view = $component->render();
+    $data = $view->getData();
+
+    expect($data['permission'])->toBe(AddressBookRule::PERM_READ)
+        ->and($data['canWriteEntries'])->toBeFalse()
+        ->and($data['canManage'])->toBeFalse();
+
+    Livewire::actingAs($user)
+        ->test(AddressBookManager::class)
+        ->set('selectedBookId', $book->id)
+        ->set('ruleSubjectType', 'everyone')
+        ->set('rulePermission', AddressBookRule::PERM_FULL)
+        ->call('addRule');
+
+    expect($book->rules()->count())->toBe(0);
+});
+
+test('a delegated address book editor retains the owned book permissions', function () {
+    $user = addressBookUserWithConsoleLevel('rw');
+    $book = AddressBook::create([
+        'name' => 'Editor-owned shared book',
+        'owner_user_id' => $user->id,
+        'is_personal' => false,
+    ]);
+
+    $this->actingAs($user);
+    $component = app(AddressBookManager::class);
+    $component->mount();
+    $component->selectedBookId = $book->id;
+    $view = $component->render();
+    $data = $view->getData();
+
+    expect($data['permission'])->toBe(AddressBookRule::PERM_FULL)
+        ->and($data['canWriteEntries'])->toBeTrue()
+        ->and($data['canManage'])->toBeTrue();
+
+    $component->entryRustdeskId = 'editor-allowed-peer';
+    $component->saveEntry();
+    $component->ruleSubjectType = 'everyone';
+    $component->rulePermission = AddressBookRule::PERM_READ;
+    $component->addRule();
+
+    expect($book->entries()->where('rustdesk_id', 'editor-allowed-peer')->exists())->toBeTrue()
+        ->and($book->rules()->where('subject_type', 'everyone')->exists())->toBeTrue();
+});
+
+test('a delegated address book viewer cannot add devices to a book from the device list', function () {
+    $user = addressBookUserWithConsoleLevel('r');
+    $book = AddressBook::personalFor($user);
+    $device = Device::create([
+        'rustdesk_id' => 'readonly-device-list-peer',
+        'uuid' => 'readonly-device-list-peer-uuid',
+        'status' => Device::STATUS_ACTIVE,
+        'user_id' => $user->id,
+    ]);
+
+    expect($book->permissionFor($user))->toBe(AddressBookRule::PERM_FULL)
+        ->and(Device::visibleTo($user)->whereKey($device->id)->exists())->toBeTrue();
+
+    $this->actingAs($user);
+    $component = app(DeviceList::class);
+    $component->selected = [(string) $device->id];
+    $component->abBookId = $book->id;
+
+    expect(fn () => $component->openAbPicker())
+        ->toThrow(HttpException::class);
+    expect(fn () => $component->addSelectedToBook())
+        ->toThrow(HttpException::class);
+
+    expect($book->entries()->where('rustdesk_id', $device->rustdesk_id)->exists())->toBeFalse();
+});
+
+test('a delegated address book editor can add devices to a book from the device list', function () {
+    $user = addressBookUserWithConsoleLevel('rw');
+    $book = AddressBook::personalFor($user);
+    $device = Device::create([
+        'rustdesk_id' => 'editor-device-list-peer',
+        'uuid' => 'editor-device-list-peer-uuid',
+        'status' => Device::STATUS_ACTIVE,
+        'user_id' => $user->id,
+    ]);
+
+    $this->actingAs($user);
+    $component = app(DeviceList::class);
+    $component->selected = [(string) $device->id];
+    $component->abBookId = $book->id;
+    $component->addSelectedToBook();
+
+    expect($book->entries()->where('rustdesk_id', $device->rustdesk_id)->exists())->toBeTrue();
+});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,0 +1,8 @@
+<?php
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+pest()->extend(TestCase::class)
+    ->use(RefreshDatabase::class)
+    ->in('Feature');

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Tests;
+
+use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
+
+abstract class TestCase extends BaseTestCase
+{
+    //
+}


### PR DESCRIPTION
## Summary
- enforce delegated Address Books `r` as read-only even when the user owns the selected book or has a Full per-book rule
- route AddressBookManager mutator authorization and rendered write controls through the effective console-permission clamp
- protect the Devices-page “Add to Address Book” open/submit actions with `address_book: rw`, hide the action for viewers, and return no writable targets to tampered component state
- preserve current behavior for editors, administrators, and underlying per-book permission tiers

## Root cause
`AddressBookManager::permission()` correctly intersected the delegated console role with per-book permission, but `authorizeBook()` and `render()` called raw `permissionFor()` instead. `DeviceList::writableBooks()` repeated the same raw-permission bypass, while its public Livewire open and submit actions had no address-book console authorization.

## Verification
- canonical `composer test`: **5 tests, 16 assertions passed**
- RED before fix:
  - viewer entry mutation created a row
  - viewer-owned shared book rendered Full instead of Read
  - Devices-page mutator added the selected peer to a viewer-owned book
- GREEN after fix: **5 tests, 16 assertions**
- covers denied personal-book mutation, clamped shared-book render data, denied shared-rule creation, denied Devices-page open/submit, and preserved editor behavior through both screens
- Pint, PHP syntax, Composer validation, Laravel config/route/Blade compilation, static added-line scan, and `git diff --check` passed

No dependency, schema, or generated-asset changes.
