### PR TITLE
perf: bound address-book permission queries

### DIFF
--- a/app/Http/Controllers/Api/AddressBookController.php
+++ b/app/Http/Controllers/Api/AddressBookController.php
@@ -368,12 +368,16 @@ class AddressBookController extends Controller
      */
     private function accessibleSharedBooks(User $user)
     {
+        $groupIds = $user->is_admin
+            ? []
+            : $user->groups()->pluck('user_groups.id')->all();
+
         return AddressBook::query()
             ->where('is_personal', false)
             ->with(['owner', 'rules'])
             ->get()
-            ->map(function (AddressBook $book) use ($user) {
-                return ['book' => $book, 'rule' => $this->ruleFor($book, $user)];
+            ->map(function (AddressBook $book) use ($user, $groupIds) {
+                return ['book' => $book, 'rule' => $this->ruleFor($book, $user, $groupIds)];
             })
             ->filter(fn (array $row) => $row['rule'] > 0)
             ->sortBy(fn (array $row) => $row['book']->name)
@@ -385,9 +389,9 @@ class AddressBookController extends Controller
      * Delegates to AddressBook::permissionFor so the console and the client API
      * share one ro / rw / full authority (PLAN B4).
      */
-    private function ruleFor(AddressBook $book, User $user): int
+    private function ruleFor(AddressBook $book, User $user, ?array $groupIds = null): int
     {
-        return $book->permissionFor($user);
+        return $book->permissionFor($user, $groupIds);
     }
 
     /** Resolve a book by guid and enforce the required permission level. */

--- a/app/Livewire/DeviceDetail.php
+++ b/app/Livewire/DeviceDetail.php
@@ -79,10 +79,14 @@ class DeviceDetail extends Component
 
         // Only books this user could open anyway — membership alone must not
         // reveal a shared book they have no rule for.
+        $groupIds = $user->is_admin
+            ? []
+            : $user->groups()->pluck('user_groups.id')->all();
         $books = AddressBook::query()
             ->whereHas('entries', fn ($q) => $q->where('rustdesk_id', $device->rustdesk_id))
+            ->with(['owner', 'rules'])
             ->get()
-            ->filter(fn (AddressBook $b) => $b->permissionFor($user) > 0)
+            ->filter(fn (AddressBook $b) => $b->permissionFor($user, $groupIds) > 0)
             ->values();
 
         return view('livewire.device-detail', [

--- a/app/Models/AddressBook.php
+++ b/app/Models/AddressBook.php
@@ -78,9 +78,12 @@ class AddressBook extends Model
      *   PERM_FULL (3)       = manage entries + tags + rules
      *
      * Owners (and admins) always have full control; personal books are private
-     * to their owner.
+     * to their owner. Callers evaluating many books may pass the user's group
+     * ids once to avoid repeating the same membership query for every book.
+     *
+     * @param  array<int, int|string>|null  $groupIds
      */
-    public function permissionFor(User $user): int
+    public function permissionFor(User $user, ?array $groupIds = null): int
     {
         if ($this->is_personal) {
             if ($this->owner_user_id === $user->id) {
@@ -99,14 +102,17 @@ class AddressBook extends Model
             return AddressBookRule::PERM_FULL;
         }
 
-        $groupIds = $user->groups()->pluck('user_groups.id')->all();
+        $groupIds = array_map(
+            'intval',
+            $groupIds ?? $user->groups()->pluck('user_groups.id')->all(),
+        );
 
         return (int) $this->rules
             ->filter(function (AddressBookRule $rule) use ($user, $groupIds) {
                 return match ($rule->subject_type) {
                     'everyone' => true,
                     'user' => (int) $rule->subject_id === $user->id,
-                    'group' => in_array((int) $rule->subject_id, array_map('intval', $groupIds), true),
+                    'group' => in_array((int) $rule->subject_id, $groupIds, true),
                     default => false,
                 };
             })

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true">
+    <testsuites>
+        <testsuite name="Feature">
+            <directory>tests/Feature</directory>
+        </testsuite>
+    </testsuites>
+    <source>
+        <include>
+            <directory>app</directory>
+        </include>
+    </source>
+    <php>
+        <env name="APP_ENV" value="testing"/>
+        <env name="APP_MAINTENANCE_DRIVER" value="file"/>
+        <!-- Fixed public test-only key; never use outside the test environment. -->
+        <env name="APP_KEY" value="base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="/>
+        <env name="APP_URL" value="http://localhost"/>
+        <env name="BCRYPT_ROUNDS" value="4"/>
+        <env name="BROADCAST_CONNECTION" value="null"/>
+        <env name="CACHE_STORE" value="array"/>
+        <env name="DB_CONNECTION" value="sqlite"/>
+        <env name="DB_DATABASE" value=":memory:"/>
+        <env name="DB_URL" value=""/>
+        <env name="MAIL_MAILER" value="array"/>
+        <env name="QUEUE_CONNECTION" value="sync"/>
+        <env name="SESSION_DRIVER" value="array"/>
+    </php>
+</phpunit>

--- a/tests/Feature/DeviceDetailAddressBookQueryTest.php
+++ b/tests/Feature/DeviceDetailAddressBookQueryTest.php
@@ -1,0 +1,119 @@
+<?php
+
+use App\Livewire\DeviceDetail;
+use App\Models\AddressBook;
+use App\Models\AddressBookRule;
+use App\Models\ClientToken;
+use App\Models\Device;
+use App\Models\Role;
+use App\Models\User;
+use App\Models\UserGroup;
+use Illuminate\Support\Facades\DB;
+use Livewire\Livewire;
+
+function deviceDetailAddressBookFixture(int $bookCount = 25): array
+{
+    $role = Role::create([
+        'name' => 'Device detail address books '.fake()->unique()->word(),
+        'permissions' => Role::normalizePermissions([
+            'device' => 'r',
+            'audit' => 'none',
+        ]),
+    ]);
+    $user = User::factory()->create(['role_id' => $role->id]);
+    $group = UserGroup::create(['name' => 'Shared books '.fake()->unique()->word()]);
+    $user->groups()->attach($group);
+    $device = Device::create([
+        'rustdesk_id' => 'device-detail-peer',
+        'uuid' => 'device-detail-address-book-perf',
+        'status' => Device::STATUS_ACTIVE,
+        'user_id' => $user->id,
+    ]);
+
+    for ($index = 1; $index <= $bookCount; $index++) {
+        $book = AddressBook::create([
+            'name' => sprintf('Shared performance book %02d', $index),
+            'owner_user_id' => User::factory()->create()->id,
+            'is_personal' => false,
+        ]);
+        $book->rules()->create([
+            'subject_type' => 'group',
+            'subject_id' => $group->id,
+            'permission' => AddressBookRule::PERM_READ,
+        ]);
+        $book->entries()->create(['rustdesk_id' => $device->rustdesk_id]);
+    }
+
+    $directWriteBook = AddressBook::create([
+        'name' => 'Direct write semantic book',
+        'owner_user_id' => User::factory()->create()->id,
+        'is_personal' => false,
+    ]);
+    $directWriteBook->rules()->create([
+        'subject_type' => 'user',
+        'subject_id' => $user->id,
+        'permission' => AddressBookRule::PERM_READ_WRITE,
+    ]);
+    $directWriteBook->entries()->create(['rustdesk_id' => $device->rustdesk_id]);
+
+    $deniedBook = AddressBook::create([
+        'name' => 'Denied hidden semantic book',
+        'owner_user_id' => User::factory()->create()->id,
+        'is_personal' => false,
+    ]);
+    $deniedBook->entries()->create(['rustdesk_id' => $device->rustdesk_id]);
+
+    return [$user, $device, $directWriteBook, $deniedBook, $group];
+}
+
+test('device detail loads only permitted matching address books with bounded queries', function () {
+    [$user, $device, $directWriteBook, $deniedBook, $group] = deviceDetailAddressBookFixture();
+    expect($directWriteBook->fresh()->load('rules')->permissionFor($user, [$group->id]))
+        ->toBe(AddressBookRule::PERM_READ_WRITE)
+        ->and($deniedBook->fresh()->load('rules')->permissionFor($user, [$group->id]))
+        ->toBe(0);
+
+    $queries = [];
+    DB::listen(function ($query) use (&$queries): void {
+        $queries[] = $query->sql;
+    });
+
+    Livewire::actingAs($user)
+        ->test(DeviceDetail::class, ['deviceId' => $device->id])
+        ->assertSee($directWriteBook->name)
+        ->assertDontSee($deniedBook->name)
+        ->assertSee('Shared performance book 01')
+        ->assertSee('Shared performance book 25');
+
+    $ruleQueries = collect($queries)->filter(fn (string $sql) => str_contains($sql, 'address_book_rules'))->count();
+    $addressBookMembershipQueries = collect($queries)->filter(fn (string $sql) => str_contains($sql, 'from "user_groups"')
+        && str_contains($sql, 'user_group_user'))->count();
+    expect($ruleQueries)->toBeLessThanOrEqual(2)
+        ->and($addressBookMembershipQueries)->toBeLessThanOrEqual(3)
+        ->and(count($queries))->toBeLessThanOrEqual(20);
+});
+
+test('shared address book profiles resolve group permissions with bounded queries', function () {
+    [$user, , $directWriteBook, $deniedBook] = deviceDetailAddressBookFixture();
+    $token = ClientToken::issue($user);
+    $queries = [];
+    DB::listen(function ($query) use (&$queries): void {
+        $queries[] = $query->sql;
+    });
+
+    $this->withToken($token->token)
+        ->postJson('/api/ab/shared/profiles?current=1&pageSize=100')
+        ->assertOk()
+        ->assertJsonPath('total', 26)
+        ->assertJsonPath('data.0.name', $directWriteBook->name)
+        ->assertJsonPath('data.0.rule', AddressBookRule::PERM_READ_WRITE)
+        ->assertJsonPath('data.1.name', 'Shared performance book 01')
+        ->assertJsonPath('data.1.rule', AddressBookRule::PERM_READ)
+        ->assertJsonPath('data.25.name', 'Shared performance book 25')
+        ->assertJsonMissing(['name' => $deniedBook->name]);
+
+    $membershipQueries = collect($queries)->filter(fn (string $sql) => str_contains($sql, 'from "user_groups"')
+        && str_contains($sql, 'user_group_user'))->count();
+    expect($membershipQueries)->toBeLessThanOrEqual(2)
+        ->and(count($queries))->toBeLessThanOrEqual(10);
+});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,0 +1,8 @@
+<?php
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+pest()->extend(TestCase::class)
+    ->use(RefreshDatabase::class)
+    ->in('Feature');

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Tests;
+
+use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
+
+abstract class TestCase extends BaseTestCase
+{
+    //
+}


### PR DESCRIPTION
## Summary
- eliminate repeated address-book rule and user-group queries on the 15-second device-detail poll
- reuse the same precomputed group membership set for shared-address-book profile authorization
- eager-load rule/owner relationships required by the existing permission semantics
- preserve owner/admin, personal/orphan, everyone, user, group, denied-book, and effective-tier behavior

## Measured impact
A deterministic 25-book group-sharing fixture produced:

| Path | Before | After |
|---|---:|---:|
| Device detail Livewire render | 60 queries | 17 queries |
| Shared profiles API | 28 queries | 7 queries |

Query-growth regressions now include 25 group-READ books, one user-specific READ_WRITE book, and one matching but denied book. The suite verifies visible names, denied-book exclusion, API totals/order, and exact rule values `2` and `1`, while bounding rule/membership and total query counts.

## Verification
- canonical `composer test`: **2 tests, 24 assertions passed**
- RED before fix:
  - device detail issued 25 address-book-rule queries against a bound of 2
  - shared profiles issued 25 identical membership queries against a bound of 2
- GREEN after fix: **2 tests, 24 assertions**
- Pint, PHP syntax, Composer validation, Laravel config/route/Blade compilation, static added-line scan, and `git diff --check` passed

No schema, dependency, or response-contract changes.
