### PR TITLE
feat: add immutable strategy revision history

### DIFF
--- a/app/Livewire/StrategyList.php
+++ b/app/Livewire/StrategyList.php
@@ -7,6 +7,7 @@ use App\Models\ConsoleAudit;
 use App\Models\Device;
 use App\Models\DeviceGroup;
 use App\Models\Strategy;
+use App\Models\StrategyRevision;
 use App\Models\User;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\Rule;
@@ -47,6 +48,14 @@ class StrategyList extends Component
 
     /** @var array<string,string> option key => form value ('' = not managed) */
     public array $formOptions = [];
+
+    public string $revisionNote = '';
+
+    public ?int $historyStrategyId = null;
+
+    public ?int $compareFromRevisionId = null;
+
+    public ?int $compareToRevisionId = null;
 
     /** Assignment editor state: strategy id, or null when closed. */
     public ?int $assigningId = null;
@@ -251,17 +260,49 @@ class StrategyList extends Component
             return;
         }
 
-        $strategy = $this->editingId ? Strategy::findOrFail($this->editingId) : new Strategy;
-        $strategy->fill([
-            'name' => $this->formName,
-            'note' => $this->formNote !== '' ? $this->formNote : null,
-            'enabled' => $this->formEnabled,
-            'is_default' => $this->formIsDefault,
-            'enforce' => $this->formEnforce,
-        ]);
-        $strategy->setOptions($options);
-        $creating = ! $strategy->exists;
-        $strategy->save();
+        $this->validate(['revisionNote' => ['nullable', 'string', 'max:500']]);
+
+        [$strategy, $creating] = DB::transaction(function () use ($options): array {
+            // A new default can displace another strategy. Serialize strategy
+            // writes and revision allocation in one stable lock order.
+            Strategy::query()->orderBy('id')->lockForUpdate()->get(['id']);
+            $strategy = $this->editingId
+                ? Strategy::query()->lockForUpdate()->findOrFail($this->editingId)
+                : new Strategy;
+            $displacedDefault = $this->formIsDefault
+                ? Strategy::query()->whereKeyNot($strategy->id ?: 0)->where('is_default', true)->lockForUpdate()->first()
+                : null;
+
+            $strategy->fill([
+                'name' => $this->formName,
+                'note' => $this->formNote !== '' ? $this->formNote : null,
+                'enabled' => $this->formEnabled,
+                'is_default' => $this->formIsDefault,
+                'enforce' => $this->formEnforce,
+            ]);
+            $strategy->setOptions($options);
+            $creating = ! $strategy->exists;
+            $strategy->save();
+
+            $revision = StrategyRevision::capture(
+                $strategy,
+                auth()->id(),
+                $this->revisionNote !== '' ? $this->revisionNote : ($creating ? 'Initial revision' : 'Saved from the strategy editor'),
+            );
+            $strategy->forceFill(['active_revision_id' => $revision->id])->saveQuietly();
+
+            if ($displacedDefault !== null) {
+                $displacedDefault->refresh();
+                $displacedRevision = StrategyRevision::capture(
+                    $displacedDefault,
+                    auth()->id(),
+                    'Default status moved to '.$strategy->name,
+                );
+                $displacedDefault->forceFill(['active_revision_id' => $displacedRevision->id])->saveQuietly();
+            }
+
+            return [$strategy, $creating];
+        });
 
         ConsoleAudit::record(
             $creating ? 'strategy.create' : 'strategy.update',
@@ -284,8 +325,15 @@ class StrategyList extends Component
     {
         $this->authorizeConsole('strategy', 'rw');
 
-        $strategy = Strategy::findOrFail($id);
-        $strategy->update(['enabled' => ! $strategy->enabled]);
+        $strategy = DB::transaction(function () use ($id): Strategy {
+            Strategy::query()->orderBy('id')->lockForUpdate()->get(['id']);
+            $strategy = Strategy::query()->lockForUpdate()->findOrFail($id);
+            $strategy->update(['enabled' => ! $strategy->enabled]);
+            $revision = StrategyRevision::capture($strategy, auth()->id(), 'Toggled enabled state');
+            $strategy->forceFill(['active_revision_id' => $revision->id])->saveQuietly();
+
+            return $strategy;
+        });
 
         ConsoleAudit::record(
             'strategy.toggle',
@@ -304,6 +352,95 @@ class StrategyList extends Component
         $strategy->delete(); // pivots cascade; the model hook re-resolves the fleet
 
         ConsoleAudit::record('strategy.delete', 'Deleted strategy '.$name, 'strategy', $name);
+    }
+
+    // -------------------------------------------------------------- history ---
+
+    public function showHistory(int $strategyId): void
+    {
+        $this->authorizeConsole('strategy', 'r');
+        $strategy = Strategy::findOrFail($strategyId);
+        $ids = $strategy->revisions()->orderBy('revision')->pluck('id');
+        $this->historyStrategyId = $strategy->id;
+        $this->compareFromRevisionId = $ids->count() > 1 ? (int) $ids->first() : null;
+        $this->compareToRevisionId = $ids->isNotEmpty() ? (int) $ids->last() : null;
+    }
+
+    public function closeHistory(): void
+    {
+        $this->reset('historyStrategyId', 'compareFromRevisionId', 'compareToRevisionId');
+        $this->resetValidation('history');
+    }
+
+    public function restoreRevision(int $revisionId): void
+    {
+        $this->authorizeConsole('strategy', 'rw');
+
+        $strategy = DB::transaction(function () use ($revisionId): Strategy {
+            $revision = StrategyRevision::query()->findOrFail($revisionId);
+            Strategy::query()->orderBy('id')->lockForUpdate()->get(['id']);
+            $strategy = Strategy::query()->lockForUpdate()->findOrFail($revision->strategy_id);
+            $revision = StrategyRevision::query()->lockForUpdate()->findOrFail($revisionId);
+            $snapshot = is_array($revision->snapshot) ? $revision->snapshot : [];
+            $displacedDefault = (bool) ($snapshot['is_default'] ?? false)
+                ? Strategy::query()->whereKeyNot($strategy->id)->where('is_default', true)->lockForUpdate()->first()
+                : null;
+
+            // Names are durable identities. Restore policy state, never a name
+            // which may now be used by another strategy.
+            $strategy->fill([
+                'note' => $snapshot['note'] ?? null,
+                'enabled' => (bool) ($snapshot['enabled'] ?? true),
+                'is_default' => (bool) ($snapshot['is_default'] ?? false),
+                'enforce' => (bool) ($snapshot['enforce'] ?? false),
+            ]);
+            $strategy->setOptions(is_array($snapshot['options'] ?? null) ? $snapshot['options'] : []);
+            $strategy->save();
+
+            $newRevision = StrategyRevision::capture($strategy, auth()->id(), 'Restored revision '.$revision->revision);
+            $strategy->forceFill(['active_revision_id' => $newRevision->id])->saveQuietly();
+
+            if ($displacedDefault !== null) {
+                $displacedDefault->refresh();
+                $displacedRevision = StrategyRevision::capture(
+                    $displacedDefault,
+                    auth()->id(),
+                    'Default status moved to '.$strategy->name.' by rollback',
+                );
+                $displacedDefault->forceFill(['active_revision_id' => $displacedRevision->id])->saveQuietly();
+            }
+
+            return $strategy;
+        });
+
+        ConsoleAudit::record('strategy.rollback', 'Restored an earlier revision of strategy '.$strategy->name, 'strategy', $strategy->name);
+    }
+
+    public function getHistoryStrategyProperty(): ?Strategy
+    {
+        return $this->historyStrategyId ? Strategy::find($this->historyStrategyId) : null;
+    }
+
+    public function getRevisionHistoryProperty()
+    {
+        return $this->historyStrategyId
+            ? StrategyRevision::query()->where('strategy_id', $this->historyStrategyId)->with('creator')->orderByDesc('revision')->get()
+            : collect();
+    }
+
+    /** @return array<int,array{key:string,before:mixed,after:mixed}> */
+    public function getRevisionComparisonProperty(): array
+    {
+        if (! $this->historyStrategyId || ! $this->compareFromRevisionId || ! $this->compareToRevisionId) {
+            return [];
+        }
+
+        $revisions = StrategyRevision::query()->where('strategy_id', $this->historyStrategyId)
+            ->whereIn('id', [$this->compareFromRevisionId, $this->compareToRevisionId])->get()->keyBy('id');
+
+        return $revisions->has($this->compareFromRevisionId) && $revisions->has($this->compareToRevisionId)
+            ? StrategyRevision::diffSnapshots($revisions[$this->compareFromRevisionId]->snapshot, $revisions[$this->compareToRevisionId]->snapshot)
+            : [];
     }
 
     // --------------------------------------------------------- assignments ---
@@ -460,6 +597,9 @@ class StrategyList extends Component
             'strategies' => $strategies,
             'catalog' => self::catalog(),
             'assigning' => $this->assigningId ? $strategies->firstWhere('id', $this->assigningId) : null,
+            'historyStrategy' => $this->historyStrategy,
+            'revisionHistory' => $this->revisionHistory,
+            'revisionComparison' => $this->revisionComparison,
         ] + $this->assignCandidates());
 
         // (assignCandidates() is only non-empty while the assignment modal is open)

--- a/app/Models/Strategy.php
+++ b/app/Models/Strategy.php
@@ -4,7 +4,10 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Facades\DB;
 
 /**
@@ -30,6 +33,8 @@ use Illuminate\Support\Facades\DB;
 #[Fillable(['name', 'note', 'enabled', 'is_default', 'enforce', 'options'])]
 class Strategy extends Model
 {
+    use SoftDeletes;
+
     /** @var array<string,string> Assignment levels, highest precedence first. */
     public const LEVEL_DEVICE = 'device';
 
@@ -171,8 +176,21 @@ class Strategy extends Model
 
         static::deleted(function (Strategy $strategy) {
             self::$anyEnabledCache = null;
-            // Pivot rows cascade at the DB level; the cached column does not.
             static::recomputeAll();
+        });
+
+        static::deleting(function (Strategy $strategy) {
+            // Revision history holds a restricted foreign key to the strategy,
+            // so delete live routing state while retaining the historical owner.
+            foreach (self::PIVOTS as [$table]) {
+                DB::table($table)->where('strategy_id', $strategy->id)->delete();
+            }
+        });
+
+        static::restoring(function (Strategy $strategy) {
+            if ($strategy->is_default && static::query()->where('is_default', true)->exists()) {
+                $strategy->is_default = false;
+            }
         });
     }
 
@@ -260,6 +278,29 @@ class Strategy extends Model
     public function setOptions(array $options): void
     {
         $this->options = self::sanitizeOptions($options);
+    }
+
+    /** @return array{name:string,note:?string,enabled:bool,is_default:bool,enforce:bool,options:array<string,string>} */
+    public function snapshot(): array
+    {
+        return [
+            'name' => $this->name,
+            'note' => $this->note,
+            'enabled' => (bool) $this->enabled,
+            'is_default' => (bool) $this->is_default,
+            'enforce' => (bool) $this->enforce,
+            'options' => $this->optionMap(),
+        ];
+    }
+
+    public function revisions(): HasMany
+    {
+        return $this->hasMany(StrategyRevision::class)->orderByDesc('revision');
+    }
+
+    public function activeRevision(): BelongsTo
+    {
+        return $this->belongsTo(StrategyRevision::class, 'active_revision_id');
     }
 
     /** @return array<string,array<string,array{group:string,type:string,values?:array<int,string>,min?:int,max?:int}>> */

--- a/app/Models/StrategyRevision.php
+++ b/app/Models/StrategyRevision.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Facades\DB;
+
+#[Fillable(['strategy_id', 'revision', 'snapshot', 'change_note', 'created_by', 'created_by_name', 'affected_devices'])]
+class StrategyRevision extends Model
+{
+    protected static function booted(): void
+    {
+        static::updating(function (): never {
+            throw new \LogicException('Strategy revisions are immutable.');
+        });
+
+        static::deleting(function (): never {
+            throw new \LogicException('Strategy revisions are immutable.');
+        });
+    }
+
+    protected function casts(): array
+    {
+        return [
+            'snapshot' => 'array',
+            'revision' => 'integer',
+            'affected_devices' => 'integer',
+        ];
+    }
+
+    public function strategy(): BelongsTo
+    {
+        return $this->belongsTo(Strategy::class)->withTrashed();
+    }
+
+    public function creator(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'created_by');
+    }
+
+    /**
+     * @param  array<string,mixed>  $before
+     * @param  array<string,mixed>  $after
+     * @return array<int,array{key:string,before:mixed,after:mixed}>
+     */
+    public static function diffSnapshots(array $before, array $after): array
+    {
+        $changes = [];
+
+        foreach (['name', 'note', 'enabled', 'is_default', 'enforce'] as $key) {
+            if (($before[$key] ?? null) !== ($after[$key] ?? null)) {
+                $changes[] = ['key' => $key, 'before' => $before[$key] ?? null, 'after' => $after[$key] ?? null];
+            }
+        }
+
+        $beforeOptions = is_array($before['options'] ?? null) ? $before['options'] : [];
+        $afterOptions = is_array($after['options'] ?? null) ? $after['options'] : [];
+        foreach (array_unique([...array_keys($beforeOptions), ...array_keys($afterOptions)]) as $key) {
+            if (($beforeOptions[$key] ?? null) !== ($afterOptions[$key] ?? null)) {
+                $changes[] = [
+                    'key' => 'options.'.$key,
+                    'before' => $beforeOptions[$key] ?? null,
+                    'after' => $afterOptions[$key] ?? null,
+                ];
+            }
+        }
+
+        return $changes;
+    }
+
+    public static function capture(Strategy $strategy, ?int $userId, ?string $changeNote = null): self
+    {
+        return static::captureSnapshot($strategy, $strategy->snapshot(), $userId, $changeNote);
+    }
+
+    /** @param array<string,mixed> $snapshot */
+    public static function captureSnapshot(
+        Strategy $strategy,
+        array $snapshot,
+        ?int $userId,
+        ?string $changeNote = null,
+        ?int $affectedDevices = null,
+    ): self {
+        return DB::transaction(function () use ($strategy, $snapshot, $userId, $changeNote, $affectedDevices): self {
+            if ($changeNote !== null && mb_strlen($changeNote) > 500) {
+                throw new \InvalidArgumentException('Strategy revision notes may not exceed 500 characters.');
+            }
+
+            // Locking the owning strategy serializes allocation even when this is
+            // the first revision and MAX(revision) has no row to lock.
+            Strategy::query()->whereKey($strategy->id)->lockForUpdate()->firstOrFail();
+
+            $snapshot = [
+                'name' => (string) ($snapshot['name'] ?? $strategy->name),
+                'note' => isset($snapshot['note']) ? (string) $snapshot['note'] : null,
+                'enabled' => (bool) ($snapshot['enabled'] ?? $strategy->enabled),
+                'is_default' => (bool) ($snapshot['is_default'] ?? $strategy->is_default),
+                'enforce' => (bool) ($snapshot['enforce'] ?? $strategy->enforce),
+                'options' => Strategy::sanitizeOptions(is_array($snapshot['options'] ?? null) ? $snapshot['options'] : []),
+            ];
+
+            return static::query()->create([
+                'strategy_id' => $strategy->id,
+                'revision' => (int) static::query()->where('strategy_id', $strategy->id)->max('revision') + 1,
+                'snapshot' => $snapshot,
+                'change_note' => $changeNote,
+                'created_by' => $userId,
+                'created_by_name' => $userId === null ? null : User::query()->whereKey($userId)->value('username'),
+                'affected_devices' => $affectedDevices ?? $strategy->resolvedDevices()->count(),
+            ]);
+        });
+    }
+}

--- a/database/migrations/2026_08_24_000010_create_strategy_revision_history.php
+++ b/database/migrations/2026_08_24_000010_create_strategy_revision_history.php
@@ -1,0 +1,100 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $decodeLegacyOptions = static function (object $strategy): array {
+            try {
+                $rawOptions = $strategy->options === null ? '[]' : (string) $strategy->options;
+                $options = json_decode($rawOptions, true, 512, JSON_THROW_ON_ERROR);
+            } catch (JsonException $exception) {
+                throw new RuntimeException(
+                    "Cannot create a baseline revision for strategy {$strategy->id}: options contains invalid JSON.",
+                    previous: $exception,
+                );
+            }
+
+            if (! is_array($options) || ($options !== [] && array_is_list($options))) {
+                throw new RuntimeException(
+                    "Cannot create a baseline revision for strategy {$strategy->id}: options must be a JSON object.",
+                );
+            }
+
+            return $options;
+        };
+
+        // Validate every legacy row before the first schema mutation. DDL is not
+        // reliably transactional across supported engines, so a bad row must
+        // leave this migration completely retryable.
+        DB::table('strategies')->orderBy('id')->cursor()->each($decodeLegacyOptions);
+
+        Schema::table('strategies', function (Blueprint $table) {
+            $table->softDeletes();
+        });
+
+        Schema::create('strategy_revisions', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('strategy_id')->constrained()->restrictOnDelete();
+            $table->unsignedInteger('revision');
+            $table->json('snapshot');
+            $table->string('change_note', 500)->nullable();
+            $table->foreignId('created_by')->nullable()->constrained('users')->nullOnDelete();
+            $table->string('created_by_name')->nullable();
+            $table->unsignedInteger('affected_devices')->default(0);
+            $table->timestamps();
+            $table->unique(['strategy_id', 'revision']);
+        });
+
+        Schema::table('strategies', function (Blueprint $table) {
+            $table->foreignId('active_revision_id')
+                ->nullable()
+                ->after('options')
+                ->constrained('strategy_revisions')
+                ->nullOnDelete();
+        });
+
+        // Existing strategies become revision 1 without changing their live
+        // behavior. Keep the decoder here as defense in depth after preflight.
+        DB::table('strategies')->orderBy('id')->each(function (object $strategy) use ($decodeLegacyOptions): void {
+            $revisionId = DB::table('strategy_revisions')->insertGetId([
+                'strategy_id' => $strategy->id,
+                'revision' => 1,
+                'snapshot' => json_encode([
+                    'name' => $strategy->name,
+                    'note' => $strategy->note,
+                    'enabled' => (bool) $strategy->enabled,
+                    'is_default' => (bool) $strategy->is_default,
+                    'enforce' => (bool) $strategy->enforce,
+                    'options' => $decodeLegacyOptions($strategy),
+                ], JSON_THROW_ON_ERROR),
+                'change_note' => 'Baseline created during strategy revision history upgrade',
+                'created_by' => null,
+                'created_by_name' => null,
+                'affected_devices' => DB::table('devices')->where('strategy_id_resolved', $strategy->id)->count(),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+
+            DB::table('strategies')->where('id', $strategy->id)->update(['active_revision_id' => $revisionId]);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('strategies', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('active_revision_id');
+        });
+
+        Schema::dropIfExists('strategy_revisions');
+
+        Schema::table('strategies', function (Blueprint $table) {
+            $table->dropSoftDeletes();
+        });
+    }
+};

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true">
+    <testsuites>
+        <testsuite name="Feature">
+            <directory>tests/Feature</directory>
+        </testsuite>
+    </testsuites>
+    <source>
+        <include><directory>app</directory></include>
+    </source>
+    <php>
+        <env name="APP_ENV" value="testing" force="true"/>
+        <env name="APP_KEY" value="base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=" force="true"/>
+        <env name="APP_MAINTENANCE_DRIVER" value="file" force="true"/>
+        <env name="BCRYPT_ROUNDS" value="4" force="true"/>
+        <env name="CACHE_STORE" value="array" force="true"/>
+        <env name="DB_CONNECTION" value="sqlite"/>
+        <env name="DB_DATABASE" value=":memory:"/>
+        <env name="MAIL_MAILER" value="array" force="true"/>
+        <env name="PULSE_ENABLED" value="false" force="true"/>
+        <env name="QUEUE_CONNECTION" value="sync" force="true"/>
+        <env name="SESSION_DRIVER" value="array" force="true"/>
+        <env name="TELESCOPE_ENABLED" value="false" force="true"/>
+    </php>
+</phpunit>

--- a/resources/views/livewire/strategy-list.blade.php
+++ b/resources/views/livewire/strategy-list.blade.php
@@ -77,11 +77,12 @@
                                 </div>
                             </td>
                             <td class="text-end rd-rowact">
-                                <a href="javascript:void(0);" class="rd-act me-2" wire:click="openAssign({{ $strategy->id }})">Assign</a>
-                                <a href="javascript:void(0);" class="rd-act me-2" wire:click="edit({{ $strategy->id }})">Edit</a>
-                                <a href="javascript:void(0);" class="text-danger"
+                                <button type="button" class="btn btn-link btn-sm p-0 me-2 rd-act" wire:click="showHistory({{ $strategy->id }})">History</button>
+                                <button type="button" class="btn btn-link btn-sm p-0 me-2 rd-act" wire:click="openAssign({{ $strategy->id }})">Assign</button>
+                                <button type="button" class="btn btn-link btn-sm p-0 me-2 rd-act" wire:click="edit({{ $strategy->id }})">Edit</button>
+                                <button type="button" class="btn btn-link btn-sm p-0 text-danger"
                                    wire:click="deleteStrategy({{ $strategy->id }})"
-                                   wire:confirm="Delete strategy {{ $strategy->name }}? Devices assigned to it fall back to the default strategy, and the options it pushed are reset to the client defaults on the next heartbeat.">Delete</a>
+                                   wire:confirm="Delete strategy {{ $strategy->name }}? Devices assigned to it fall back to the default strategy, and the options it pushed are reset to the client defaults on the next heartbeat.">Delete</button>
                             </td>
                         </tr>
                     @empty
@@ -133,13 +134,15 @@
                                     <i class="ri-folder-line ms-2 me-1"></i>{{ $strategy->device_groups_count }}
                                 </span>
                                 <div class="rd-mini-acts">
-                                    <a href="javascript:void(0);" class="rd-iconbtn" title="Assign"
-                                       wire:click="openAssign({{ $strategy->id }})"><i class="ri-links-line"></i></a>
-                                    <a href="javascript:void(0);" class="rd-iconbtn" title="Edit"
-                                       wire:click="edit({{ $strategy->id }})"><i class="ri-pencil-line"></i></a>
-                                    <a href="javascript:void(0);" class="rd-iconbtn text-danger" title="Delete"
+                                    <button type="button" class="rd-iconbtn border-0" title="Revision history" aria-label="Revision history for {{ $strategy->name }}"
+                                       wire:click="showHistory({{ $strategy->id }})"><i class="ri-history-line"></i></button>
+                                    <button type="button" class="rd-iconbtn border-0" title="Assign" aria-label="Assign {{ $strategy->name }}"
+                                       wire:click="openAssign({{ $strategy->id }})"><i class="ri-links-line"></i></button>
+                                    <button type="button" class="rd-iconbtn border-0" title="Edit" aria-label="Edit {{ $strategy->name }}"
+                                       wire:click="edit({{ $strategy->id }})"><i class="ri-pencil-line"></i></button>
+                                    <button type="button" class="rd-iconbtn border-0 text-danger" title="Delete" aria-label="Delete {{ $strategy->name }}"
                                        wire:click="deleteStrategy({{ $strategy->id }})"
-                                       wire:confirm="Delete strategy {{ $strategy->name }}? Devices assigned to it fall back to the default strategy."><i class="ri-delete-bin-line"></i></a>
+                                       wire:confirm="Delete strategy {{ $strategy->name }}? Devices assigned to it fall back to the default strategy."><i class="ri-delete-bin-line"></i></button>
                                 </div>
                             </div>
                     </div>
@@ -405,6 +408,80 @@
                             <span wire:loading wire:target="saveAssign">Saving…</span>
                         </button>
                     </div>
+                </div>
+            </div>
+        </div>
+        <div class="modal-backdrop fade show"></div>
+    @endif
+
+    {{-- Immutable revision history and comparison --}}
+    @if ($historyStrategy)
+        <div class="modal fade show d-block" tabindex="-1" role="dialog" aria-modal="true"
+             aria-labelledby="strategy-history-title" wire:keydown.escape.window="closeHistory"
+             style="background: rgba(0,0,0,.65);" wire:key="strategy-history">
+            <div class="modal-dialog modal-xl modal-dialog-centered modal-dialog-scrollable">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <div>
+                            <h5 class="modal-title" id="strategy-history-title">{{ $historyStrategy->name }} revision history</h5>
+                            <small class="text-muted">Restoring creates a new revision; existing history is never rewritten.</small>
+                        </div>
+                        <button type="button" class="btn-close" wire:click="closeHistory" aria-label="Close history"></button>
+                    </div>
+                    <div class="modal-body">
+                        @error('history') <div class="alert alert-danger" role="alert">{{ $message }}</div> @enderror
+                        @if ($revisionHistory->isNotEmpty())
+                            <div class="row g-2 align-items-end mb-3">
+                                <div class="col-12 col-md-5">
+                                    <label class="form-label" for="compare-from">Compare from</label>
+                                    <select id="compare-from" class="form-select" wire:model.live="compareFromRevisionId">
+                                        <option value="">Choose revision</option>
+                                        @foreach ($revisionHistory->sortBy('revision') as $revision)
+                                            <option value="{{ $revision->id }}">Revision {{ $revision->revision }}</option>
+                                        @endforeach
+                                    </select>
+                                </div>
+                                <div class="col-12 col-md-5">
+                                    <label class="form-label" for="compare-to">Compare to</label>
+                                    <select id="compare-to" class="form-select" wire:model.live="compareToRevisionId">
+                                        <option value="">Choose revision</option>
+                                        @foreach ($revisionHistory->sortBy('revision') as $revision)
+                                            <option value="{{ $revision->id }}">Revision {{ $revision->revision }}</option>
+                                        @endforeach
+                                    </select>
+                                </div>
+                            </div>
+                            @if ($compareFromRevisionId && $compareToRevisionId)
+                                <div class="table-responsive mb-4">
+                                    <table class="table table-sm"><thead><tr><th>Field</th><th>From</th><th>To</th></tr></thead><tbody>
+                                    @forelse ($revisionComparison as $change)
+                                        <tr><td><code>{{ $change['key'] }}</code></td><td>{{ is_bool($change['before']) ? ($change['before'] ? 'Yes' : 'No') : ($change['before'] ?? 'Not managed') }}</td><td>{{ is_bool($change['after']) ? ($change['after'] ? 'Yes' : 'No') : ($change['after'] ?? 'Not managed') }}</td></tr>
+                                    @empty
+                                        <tr><td colspan="3" class="text-muted">These revisions are identical.</td></tr>
+                                    @endforelse
+                                    </tbody></table>
+                                </div>
+                            @endif
+                            <div class="list-group">
+                                @foreach ($revisionHistory as $revision)
+                                    <div class="list-group-item d-flex flex-column flex-md-row justify-content-between gap-2" wire:key="revision-{{ $revision->id }}">
+                                        <div>
+                                            <strong>Revision {{ $revision->revision }}</strong>
+                                            @if ($historyStrategy->active_revision_id === $revision->id)<span class="badge bg-success-subtle text-success ms-1">Active</span>@endif
+                                            <div class="text-muted fs-13">{{ $revision->created_by_name ?? $revision->creator?->username ?? 'System' }} · {{ $revision->created_at->timezone(config('app.timezone'))->format('M j, Y g:i A T') }} · {{ $revision->affected_devices }} affected device(s)</div>
+                                            @if ($revision->change_note)<div class="mt-1">{{ $revision->change_note }}</div>@endif
+                                        </div>
+                                        @if ($historyStrategy->active_revision_id !== $revision->id)
+                                            <button type="button" class="btn btn-sm btn-outline-warning align-self-md-center" wire:click="restoreRevision({{ $revision->id }})" wire:confirm="Restore revision {{ $revision->revision }} as a new revision?">Restore as new revision</button>
+                                        @endif
+                                    </div>
+                                @endforeach
+                            </div>
+                        @else
+                            <div class="text-muted">No revisions have been captured yet.</div>
+                        @endif
+                    </div>
+                    <div class="modal-footer"><button type="button" class="btn btn-light" wire:click="closeHistory">Close</button></div>
                 </div>
             </div>
         </div>

--- a/tests/Feature/StrategyRevisionHistoryTest.php
+++ b/tests/Feature/StrategyRevisionHistoryTest.php
@@ -1,0 +1,288 @@
+<?php
+
+use App\Livewire\StrategyList;
+use App\Models\Strategy;
+use App\Models\StrategyRevision;
+use App\Models\User;
+use Illuminate\Database\QueryException;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Schema;
+use Livewire\Livewire;
+
+it('captures an immutable first revision for a strategy', function () {
+    $strategy = Strategy::create([
+        'name' => 'Locked down',
+        'enabled' => true,
+        'options' => ['enable-file-transfer' => 'N'],
+    ]);
+
+    $revision = StrategyRevision::capture($strategy, null, 'Initial policy');
+
+    expect(Schema::hasTable('strategy_revisions'))->toBeTrue()
+        ->and($revision->revision)->toBe(1)
+        ->and($revision->snapshot)->toMatchArray([
+            'name' => 'Locked down',
+            'options' => ['enable-file-transfer' => 'N'],
+        ])
+        ->and(fn () => $revision->update(['change_note' => 'Tampered']))
+        ->toThrow(LogicException::class)
+        ->and(fn () => $revision->delete())
+        ->toThrow(LogicException::class);
+});
+
+it('retains revision evidence and the creator name after related rows are deleted', function () {
+    $author = User::factory()->admin()->create();
+    $authorName = $author->username;
+    $strategy = Strategy::create(['name' => 'Retained history', 'enabled' => true]);
+    $revision = StrategyRevision::capture($strategy, $author->id, 'Initial');
+
+    $author->delete();
+    $strategy->delete();
+
+    expect($revision->fresh()->created_by)->toBeNull()
+        ->and($revision->fresh()->created_by_name)->toBe($authorName)
+        ->and(Strategy::find($strategy->id))->toBeNull()
+        ->and(Strategy::withTrashed()->find($strategy->id)?->trashed())->toBeTrue()
+        ->and(StrategyRevision::find($revision->id))->not->toBeNull();
+});
+
+it('creates a revision whenever the editor saves a strategy', function () {
+    $admin = User::factory()->admin()->create();
+
+    Livewire::actingAs($admin)
+        ->test(StrategyList::class)
+        ->call('create')
+        ->set('formName', 'Editor policy')
+        ->set('formOptions.enable-file-transfer', 'N')
+        ->call('save')
+        ->assertHasNoErrors();
+
+    $strategy = Strategy::query()->where('name', 'Editor policy')->firstOrFail();
+
+    expect($strategy->revisions()->count())->toBe(1)
+        ->and($strategy->active_revision_id)->toBe($strategy->revisions()->value('id'));
+});
+
+it('compares revisions and restores a historical snapshot as a new revision', function () {
+    $admin = User::factory()->admin()->create();
+    $strategy = Strategy::create(['name' => 'Rollback policy', 'enabled' => true]);
+    $first = StrategyRevision::captureSnapshot($strategy, [...$strategy->snapshot(), 'options' => ['enable-file-transfer' => 'N']], $admin->id, 'First');
+    $strategy->setOptions(['enable-file-transfer' => 'Y']);
+    $strategy->save();
+    $second = StrategyRevision::capture($strategy, $admin->id, 'Second');
+    $strategy->forceFill(['active_revision_id' => $second->id])->saveQuietly();
+
+    $component = Livewire::actingAs($admin)->test(StrategyList::class)
+        ->call('showHistory', $strategy->id)
+        ->set('compareFromRevisionId', $first->id)
+        ->set('compareToRevisionId', $second->id);
+
+    expect($component->get('revisionComparison'))->toContain([
+        'key' => 'options.enable-file-transfer', 'before' => 'N', 'after' => 'Y',
+    ]);
+
+    $component->call('restoreRevision', $first->id)->assertHasNoErrors();
+
+    expect($strategy->fresh()->optionMap())->toBe(['enable-file-transfer' => 'N'])
+        ->and($strategy->revisions()->pluck('revision')->all())->toBe([3, 2, 1]);
+});
+
+it('renders revision history and comparison controls in the strategy UI', function () {
+    $admin = User::factory()->admin()->create();
+    $strategy = Strategy::create(['name' => 'Visible history', 'enabled' => true]);
+    StrategyRevision::capture($strategy, $admin->id, 'Initial');
+
+    Livewire::actingAs($admin)
+        ->test(StrategyList::class)
+        ->call('showHistory', $strategy->id)
+        ->assertSee('Visible history revision history')
+        ->assertSeeHtml('id="compare-from"')
+        ->assertSee('Restoring creates a new revision');
+});
+
+it('allocates sequential revision numbers and keeps their database identity unique', function () {
+    $strategy = Strategy::create(['name' => 'Serialized capture', 'enabled' => true]);
+
+    $one = StrategyRevision::capture($strategy, null, 'One');
+    $two = StrategyRevision::capture($strategy, null, 'Two');
+
+    expect([$one->revision, $two->revision])->toBe([1, 2])
+        ->and(fn () => DB::table('strategy_revisions')->insert([
+            'strategy_id' => $strategy->id,
+            'revision' => 2,
+            'snapshot' => '{}',
+            'affected_devices' => 0,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]))->toThrow(QueryException::class);
+});
+
+it('records the strategy displaced when a restore takes back default status', function () {
+    $admin = User::factory()->admin()->create();
+    $historical = Strategy::create(['name' => 'Historical default', 'enabled' => true, 'is_default' => true]);
+    $historicalRevision = StrategyRevision::capture($historical, $admin->id, 'Was default');
+    $historical->forceFill(['active_revision_id' => $historicalRevision->id])->saveQuietly();
+
+    $current = Strategy::create(['name' => 'Current default', 'enabled' => true, 'is_default' => true]);
+    $currentRevision = StrategyRevision::capture($current, $admin->id, 'Current default');
+    $current->forceFill(['active_revision_id' => $currentRevision->id])->saveQuietly();
+
+    Livewire::actingAs($admin)->test(StrategyList::class)
+        ->call('restoreRevision', $historicalRevision->id)
+        ->assertHasNoErrors();
+
+    expect($historical->fresh()->is_default)->toBeTrue()
+        ->and($current->fresh()->is_default)->toBeFalse()
+        ->and($current->revisions()->count())->toBe(2)
+        ->and($current->revisions()->first()->snapshot['is_default'])->toBeFalse();
+});
+
+it('backfills valid legacy strategies and rolls the history schema back cleanly', function () {
+    $path = database_path('strategy-revision-history-test.sqlite');
+    File::delete($path);
+    File::put($path, '');
+    config(['database.connections.revision_history' => [
+        'driver' => 'sqlite', 'database' => $path, 'prefix' => '', 'foreign_key_constraints' => true,
+    ]]);
+    DB::purge('revision_history');
+    $previous = config('database.default');
+    config(['database.default' => 'revision_history']);
+
+    try {
+        Schema::create('users', fn ($table) => $table->id());
+        Schema::create('strategies', function ($table): void {
+            $table->id();
+            $table->string('name');
+            $table->string('note')->nullable();
+            $table->boolean('enabled');
+            $table->boolean('is_default');
+            $table->boolean('enforce');
+            $table->json('options')->nullable();
+            $table->timestamps();
+        });
+        Schema::create('devices', function ($table): void {
+            $table->id();
+            $table->foreignId('strategy_id_resolved')->nullable();
+        });
+        DB::table('strategies')->insert([
+            'name' => 'Legacy policy', 'enabled' => true, 'is_default' => false, 'enforce' => false,
+            'options' => json_encode(['enable-file-transfer' => 'N']), 'created_at' => now(), 'updated_at' => now(),
+        ]);
+
+        $migration = require database_path('migrations/2026_08_24_000010_create_strategy_revision_history.php');
+        $migration->up();
+
+        expect(Schema::hasTable('strategy_revisions'))->toBeTrue()
+            ->and(DB::table('strategy_revisions')->value('revision'))->toBe(1)
+            ->and(json_decode(DB::table('strategy_revisions')->value('snapshot'), true)['options'])->toBe(['enable-file-transfer' => 'N'])
+            ->and(DB::table('strategies')->value('active_revision_id'))->not->toBeNull();
+
+        $migration->down();
+
+        expect(Schema::hasTable('strategy_revisions'))->toBeFalse()
+            ->and(Schema::hasColumn('strategies', 'active_revision_id'))->toBeFalse()
+            ->and(Schema::hasColumn('strategies', 'deleted_at'))->toBeFalse();
+    } finally {
+        config(['database.default' => $previous]);
+        DB::purge('revision_history');
+        File::delete($path);
+    }
+});
+
+it('fails legacy preflight before making schema changes for invalid strategy options', function (string $legacyOptions) {
+    $path = database_path('strategy-revision-preflight-test.sqlite');
+    File::delete($path);
+    File::put($path, '');
+    config(['database.connections.revision_preflight' => [
+        'driver' => 'sqlite', 'database' => $path, 'prefix' => '', 'foreign_key_constraints' => true,
+    ]]);
+    DB::purge('revision_preflight');
+    $previous = config('database.default');
+    config(['database.default' => 'revision_preflight']);
+
+    try {
+        Schema::create('strategies', function ($table): void {
+            $table->id();
+            $table->string('name');
+            $table->string('note')->nullable();
+            $table->boolean('enabled');
+            $table->boolean('is_default');
+            $table->boolean('enforce');
+            $table->text('options')->nullable();
+            $table->timestamps();
+        });
+        Schema::create('devices', fn ($table) => $table->id());
+        DB::table('strategies')->insert([
+            'name' => 'Broken legacy policy', 'enabled' => true, 'is_default' => false, 'enforce' => false,
+            'options' => $legacyOptions, 'created_at' => now(), 'updated_at' => now(),
+        ]);
+
+        $migration = require database_path('migrations/2026_08_24_000010_create_strategy_revision_history.php');
+
+        expect(fn () => $migration->up())->toThrow(RuntimeException::class)
+            ->and(Schema::hasTable('strategy_revisions'))->toBeFalse()
+            ->and(Schema::hasColumn('strategies', 'deleted_at'))->toBeFalse();
+    } finally {
+        config(['database.default' => $previous]);
+        DB::purge('revision_preflight');
+        File::delete($path);
+    }
+})->with([
+    'malformed json' => '{not-json}',
+    'false' => 'false',
+    'zero' => '0',
+    'empty string value' => '""',
+    'null' => 'null',
+    'list-shaped options' => '["N"]',
+]);
+
+it('remains retryable after legacy preflight rejects a row', function () {
+    $path = database_path('strategy-revision-retry-test.sqlite');
+    File::delete($path);
+    File::put($path, '');
+    config(['database.connections.revision_retry' => [
+        'driver' => 'sqlite', 'database' => $path, 'prefix' => '', 'foreign_key_constraints' => true,
+    ]]);
+    DB::purge('revision_retry');
+    $previous = config('database.default');
+    config(['database.default' => 'revision_retry']);
+
+    try {
+        Schema::create('users', fn ($table) => $table->id());
+        Schema::create('strategies', function ($table): void {
+            $table->id();
+            $table->string('name');
+            $table->string('note')->nullable();
+            $table->boolean('enabled');
+            $table->boolean('is_default');
+            $table->boolean('enforce');
+            $table->text('options')->nullable();
+            $table->timestamps();
+        });
+        Schema::create('devices', function ($table): void {
+            $table->id();
+            $table->foreignId('strategy_id_resolved')->nullable();
+        });
+        $strategyId = DB::table('strategies')->insertGetId([
+            'name' => 'Retryable legacy policy', 'enabled' => true, 'is_default' => false, 'enforce' => false,
+            'options' => '{broken}', 'created_at' => now(), 'updated_at' => now(),
+        ]);
+        $migration = require database_path('migrations/2026_08_24_000010_create_strategy_revision_history.php');
+
+        expect(fn () => $migration->up())->toThrow(RuntimeException::class)
+            ->and(Schema::hasTable('strategy_revisions'))->toBeFalse()
+            ->and(Schema::hasColumn('strategies', 'active_revision_id'))->toBeFalse();
+
+        DB::table('strategies')->where('id', $strategyId)->update(['options' => '{"enable-audio":"N"}']);
+        $migration->up();
+
+        expect(Schema::hasTable('strategy_revisions'))->toBeTrue()
+            ->and(DB::table('strategy_revisions')->where('strategy_id', $strategyId)->count())->toBe(1)
+            ->and(DB::table('strategies')->where('id', $strategyId)->value('active_revision_id'))->not->toBeNull();
+    } finally {
+        config(['database.default' => $previous]);
+        DB::purge('revision_retry');
+        File::delete($path);
+    }
+});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,0 +1,8 @@
+<?php
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+pest()->extend(TestCase::class)
+    ->use(RefreshDatabase::class)
+    ->in('Feature');

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Tests;
+
+use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
+
+abstract class TestCase extends BaseTestCase
+{
+    //
+}


### PR DESCRIPTION
## Summary

Part 1 of 4 replacing #61.

- add immutable `strategy_revisions` rows and active-revision pointers
- validate legacy strategy JSON before schema changes, then backfill one baseline revision per strategy
- capture revisions from editor saves and default-strategy displacement
- add revision history, comparison, and restore-as-new-revision UI
- preserve revision history when a strategy is soft-deleted

## Safety and migration behavior

- preflight runs before additive DDL and rejects malformed or non-object legacy options
- backfill is deterministic and links every existing strategy to revision 1
- restore preserves the strategy's durable name and creates a new immutable revision
- down migration drops the active-revision foreign key before the revision table and removes only fields introduced here

## Scope boundaries

- no impact preview/fingerprints
- no rollout tables, scheduler, locks, or compliance reporting
- no admin API contract changes
- intentionally excludes `docs/strategy-protocol.md` and all GitHub workflow changes from #61

## Verification

- `php artisan test --compact` — **15 tests, 61 assertions passed**
- changed-file Pint check passed
- `composer validate --strict` passed
- `git diff --check` passed

Supersedes the revisions/history portion of #61. The remaining parts are submitted in dependency order.
