### PR TITLE
feat: add confirmation-gated strategy rollouts

### DIFF
--- a/app/Console/Commands/AdvanceStrategyRollouts.php
+++ b/app/Console/Commands/AdvanceStrategyRollouts.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\StrategyRollout;
+use Illuminate\Console\Command;
+
+class AdvanceStrategyRollouts extends Command
+{
+    protected $signature = 'cortendesk:advance-strategy-rollouts';
+
+    protected $description = 'Start and advance due staged strategy rollouts';
+
+    public function handle(): int
+    {
+        $advanced = StrategyRollout::advanceDue();
+        $this->components->info("Advanced {$advanced} strategy rollout(s).");
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Console/Commands/ImportLejianwen.php
+++ b/app/Console/Commands/ImportLejianwen.php
@@ -11,6 +11,7 @@ use App\Models\ClientToken;
 use App\Models\Device;
 use App\Models\DeviceGroup;
 use App\Models\LoginLog;
+use App\Models\Strategy;
 use App\Models\Tag;
 use App\Models\User;
 use App\Models\UserGroup;
@@ -120,6 +121,7 @@ class ImportLejianwen extends Command
 
         // delete() instead of truncate() so --wipe stays inside the
         // transaction (and rolls back under --dry-run).
+        Strategy::query()->orderBy('id')->lockForUpdate()->get(['id']);
         Device::withTrashed()->forceDelete();
 
         foreach ([
@@ -435,7 +437,7 @@ class ImportLejianwen extends Command
 
             $device = Device::withTrashed()->firstOrNew(['rustdesk_id' => $rustdeskId]);
             $isNew = ! $device->exists;
-            $device->fill([
+            $attributes = [
                 'uuid' => (string) $row->uuid,
                 'hostname' => trim((string) $row->hostname) ?: null,
                 'os' => trim((string) $row->os) ?: null,
@@ -450,8 +452,8 @@ class ImportLejianwen extends Command
                     ? Carbon::createFromTimestamp((int) $row->last_online_time)
                     : null,
                 'last_online_ip' => trim((string) $row->last_online_ip) ?: null,
-            ]);
-            $device->save();
+            ];
+            $device = Device::updateWithStrategyContext($device, $attributes);
             $this->track('devices', $device, $isNew);
         }
     }

--- a/app/Console/Commands/ImportLejianwen.php
+++ b/app/Console/Commands/ImportLejianwen.php
@@ -121,7 +121,8 @@ class ImportLejianwen extends Command
 
         // delete() instead of truncate() so --wipe stays inside the
         // transaction (and rolls back under --dry-run).
-        Strategy::query()->orderBy('id')->lockForUpdate()->get(['id']);
+        $strategyIds = Strategy::query()->orderBy('id')->lockForUpdate()->pluck('id')->all();
+        Strategy::guardNoOpenRollouts($strategyIds);
         Device::withTrashed()->forceDelete();
 
         foreach ([

--- a/app/Http/Controllers/AdminApi/DeviceGroupsController.php
+++ b/app/Http/Controllers/AdminApi/DeviceGroupsController.php
@@ -5,8 +5,10 @@ namespace App\Http\Controllers\AdminApi;
 use App\Models\ConsoleAudit;
 use App\Models\Device;
 use App\Models\DeviceGroup;
+use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\Rule;
 
 class DeviceGroupsController extends AdminApiController
@@ -57,13 +59,23 @@ class DeviceGroupsController extends AdminApiController
         return $this->ok($this->serialize($deviceGroup->loadCount('devices')), 'Device group updated.');
     }
 
-    public function destroy(DeviceGroup $deviceGroup): JsonResponse
+    public function destroy(Request $request, DeviceGroup $deviceGroup): JsonResponse
     {
         $name = $deviceGroup->name;
-        // Detach devices (keep them), then remove the folder.
-        $deviceGroup->devices()->update(['device_group_id' => null]);
-        $deviceGroup->userGroups()->detach();
-        $deviceGroup->delete();
+        try {
+            DB::transaction(function () use ($request, $deviceGroup): void {
+                // Detach devices (keep them), then remove the folder.
+                Device::bulkUpdateStrategyContext(
+                    Device::query()->where('device_group_id', $deviceGroup->id),
+                    ['device_group_id' => null],
+                    $this->token($request)->allows('strategy', 'rw'),
+                );
+                $deviceGroup->userGroups()->detach();
+                $deviceGroup->delete();
+            });
+        } catch (AuthorizationException) {
+            return $this->fail("Token lacks 'rw' permission on 'strategy'.", 403);
+        }
 
         ConsoleAudit::record('group.delete', 'Deleted device group '.$name.' (API)', 'group', $name);
 
@@ -78,7 +90,15 @@ class DeviceGroupsController extends AdminApiController
             return $this->fail('Device not found.', 404);
         }
 
-        $device->update(['device_group_id' => $deviceGroup->id]);
+        try {
+            $device = Device::updateWithStrategyContext(
+                $device,
+                ['device_group_id' => $deviceGroup->id],
+                $this->token($request)->allows('strategy', 'rw'),
+            );
+        } catch (AuthorizationException) {
+            return $this->fail("Token lacks 'rw' permission on 'strategy'.", 403);
+        }
 
         ConsoleAudit::record('group.update', 'Added device '.$device->rustdesk_id.' to '.$deviceGroup->name.' (API)', 'group', $deviceGroup->name);
 
@@ -94,7 +114,15 @@ class DeviceGroupsController extends AdminApiController
         }
 
         if ($device->device_group_id === $deviceGroup->id) {
-            $device->update(['device_group_id' => null]);
+            try {
+                $device = Device::updateWithStrategyContext(
+                    $device,
+                    ['device_group_id' => null],
+                    $this->token($request)->allows('strategy', 'rw'),
+                );
+            } catch (AuthorizationException) {
+                return $this->fail("Token lacks 'rw' permission on 'strategy'.", 403);
+            }
         }
 
         ConsoleAudit::record('group.update', 'Removed device '.$device->rustdesk_id.' from '.$deviceGroup->name.' (API)', 'group', $deviceGroup->name);

--- a/app/Http/Controllers/AdminApi/DevicesController.php
+++ b/app/Http/Controllers/AdminApi/DevicesController.php
@@ -6,6 +6,7 @@ use App\Models\ConsoleAudit;
 use App\Models\Device;
 use App\Models\DeviceGroup;
 use App\Models\User;
+use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 
@@ -64,7 +65,7 @@ class DevicesController extends AdminApiController
     public function enable(Device $device): JsonResponse
     {
         if ($device->trashed()) {
-            $device->restore();
+            $device = Device::restoreWithStrategyContext($device);
         }
 
         ConsoleAudit::record('device.enable', 'Enabled device '.$device->rustdesk_id.' (API)', 'device', $device->rustdesk_id);
@@ -75,7 +76,7 @@ class DevicesController extends AdminApiController
     /** POST /api/v1/devices/{device}/disable — soft-delete (revocable). */
     public function disable(Device $device): JsonResponse
     {
-        $device->delete();
+        Device::deleteWithStrategyContext($device);
 
         ConsoleAudit::record('device.disable', 'Disabled device '.$device->rustdesk_id.' (API)', 'device', $device->rustdesk_id);
 
@@ -86,7 +87,7 @@ class DevicesController extends AdminApiController
     public function destroy(Device $device): JsonResponse
     {
         $id = $device->rustdesk_id;
-        $device->forceDelete();
+        Device::deleteWithStrategyContext($device, true);
 
         ConsoleAudit::record('device.destroy', 'Destroyed device '.$id.' (API)', 'device', $id);
 
@@ -137,7 +138,15 @@ class DevicesController extends AdminApiController
             return $this->fail('Nothing to assign; provide user_(id|name) or device_group_(id|name).', 422);
         }
 
-        $device->update($changes);
+        try {
+            $device = Device::updateWithStrategyContext(
+                $device,
+                $changes,
+                $this->token($request)->allows('strategy', 'rw'),
+            );
+        } catch (AuthorizationException) {
+            return $this->fail("Token lacks 'rw' permission on 'strategy'.", 403);
+        }
 
         ConsoleAudit::record('device.assign', 'Reassigned device '.$device->rustdesk_id.' (API)', 'device', $device->rustdesk_id);
 

--- a/app/Http/Controllers/AdminApi/UsersController.php
+++ b/app/Http/Controllers/AdminApi/UsersController.php
@@ -3,7 +3,9 @@
 namespace App\Http\Controllers\AdminApi;
 
 use App\Models\ConsoleAudit;
+use App\Models\Device;
 use App\Models\User;
+use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
@@ -113,8 +115,18 @@ class UsersController extends AdminApiController
         }
 
         $username = $user->username;
-        $user->devices()->update(['user_id' => null]);
-        $user->delete();
+        try {
+            DB::transaction(function () use ($request, $user): void {
+                Device::bulkUpdateStrategyContext(
+                    Device::query()->where('user_id', $user->id),
+                    ['user_id' => null],
+                    $this->token($request)->allows('strategy', 'rw'),
+                );
+                $user->delete();
+            });
+        } catch (AuthorizationException) {
+            return $this->fail("Token lacks 'rw' permission on 'strategy'.", 403);
+        }
 
         ConsoleAudit::record('user.delete', 'Deleted user '.$username.' (API)', 'user', $username);
 

--- a/app/Http/Controllers/Api/DeviceCliController.php
+++ b/app/Http/Controllers/Api/DeviceCliController.php
@@ -9,12 +9,13 @@ use App\Models\ApiToken;
 use App\Models\ConsoleAudit;
 use App\Models\Device;
 use App\Models\DeviceGroup;
-use App\Models\Strategy;
 use App\Models\Tag;
 use App\Models\User;
+use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Crypt;
+use Illuminate\Support\Facades\DB;
 
 /**
  * RustDesk client `--assign` support (PLAN B2).
@@ -99,6 +100,12 @@ class DeviceCliController extends Controller
         if ($request->filled('strategy_name') && ! $this->tokenAllows($request, 'strategy')) {
             return $this->message("Token lacks 'rw' permission on 'strategy'.", 403);
         }
+        if ($request->filled('strategy_name')) {
+            return $this->message(
+                'Direct strategy assignment requires a reviewed impact confirmation in Strategies → Assign.',
+                409,
+            );
+        }
 
         // Resolve the named user / device group up front so a bad name fails the
         // whole request before we mutate anything.
@@ -120,18 +127,6 @@ class DeviceCliController extends Controller
             $groupChange = $group->id;
         }
 
-        // A named strategy becomes a DEVICE-level assignment (the highest
-        // precedence level), which is what `--strategy_name` means at
-        // enrollment: this machine gets this policy regardless of who owns it.
-        $strategyChange = null;
-        if ($request->filled('strategy_name')) {
-            $strategy = Strategy::where('name', $request->input('strategy_name'))->first();
-            if (! $strategy) {
-                return $this->message("Strategy '".$request->input('strategy_name')."' not found.", 404);
-            }
-            $strategyChange = $strategy->id;
-        }
-
         // Resolve the address book (if any) before mutating.
         $book = null;
         if ($request->filled('address_book_name')) {
@@ -150,39 +145,42 @@ class DeviceCliController extends Controller
         if ($isNew) {
             $device = new Device(['rustdesk_id' => $id]);
         }
-        $device->uuid = $uuid;
 
-        // A deploy/assign carrying a Device rw token is an authenticated,
-        // pre-approved registration (PLAN B3): it registers active regardless of
-        // the approval gate, and approves any device the gate had quarantined.
-        $device->status = Device::STATUS_ACTIVE;
-
+        $attributes = [
+            'uuid' => $uuid,
+            // A deploy/assign carrying a Device rw token is an authenticated,
+            // pre-approved registration (PLAN B3).
+            'status' => Device::STATUS_ACTIVE,
+        ];
         if ($userChange !== null) {
-            $device->user_id = $userChange;
+            $attributes['user_id'] = $userChange;
         }
         if ($groupChange !== null) {
-            $device->device_group_id = $groupChange;
+            $attributes['device_group_id'] = $groupChange;
         }
         if ($request->filled('note')) {
-            $device->note = (string) $request->input('note');
+            $attributes['note'] = (string) $request->input('note');
         }
         // Display overrides (NOT identifiers).
         if ($request->filled('device_name')) {
-            $device->hostname = (string) $request->input('device_name');
+            $attributes['hostname'] = (string) $request->input('device_name');
         }
         if ($request->filled('device_username')) {
-            $device->username = (string) $request->input('device_username');
+            $attributes['username'] = (string) $request->input('device_username');
         }
 
-        $device->save();
+        $mayChangeResolvedStrategy = $this->tokenAllows($request, 'strategy');
+        try {
+            $device = DB::transaction(
+                fn (): Device => Device::updateWithStrategyContext($device, $attributes, $mayChangeResolvedStrategy),
+            );
+        } catch (AuthorizationException $exception) {
+            return $this->message($exception->getMessage(), 403);
+        }
 
         // Add / update the address-book entry for this device.
         if ($book !== null) {
             $this->applyAddressBook($request, $book, $device);
-        }
-
-        if ($strategyChange !== null) {
-            Strategy::assignTo(Strategy::LEVEL_DEVICE, (int) $device->id, $strategyChange);
         }
 
         ConsoleAudit::record(

--- a/app/Http/Controllers/Api/DeviceCliController.php
+++ b/app/Http/Controllers/Api/DeviceCliController.php
@@ -16,6 +16,7 @@ use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Crypt;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\ValidationException;
 
 /**
  * RustDesk client `--assign` support (PLAN B2).
@@ -176,6 +177,8 @@ class DeviceCliController extends Controller
             );
         } catch (AuthorizationException $exception) {
             return $this->message($exception->getMessage(), 403);
+        } catch (ValidationException $exception) {
+            return $this->message(collect($exception->errors())->flatten()->first() ?? 'The strategy is locked by an open rollout.', 409);
         }
 
         // Add / update the address-book entry for this device.

--- a/app/Http/Controllers/Api/SyncController.php
+++ b/app/Http/Controllers/Api/SyncController.php
@@ -156,7 +156,10 @@ class SyncController extends Controller
             // update, so later heartbeats cannot rewrite history (issue #46).
             $attributes['registered_ip'] = $request->ip();
 
-            $device = Device::create(['rustdesk_id' => $id] + $attributes);
+            $device = Device::updateWithStrategyContext(
+                new Device(['rustdesk_id' => $id]),
+                $attributes,
+            );
 
             if ($device->isPending()) {
                 app(AppriseNotifications::class)->sendAfterResponse(

--- a/app/Livewire/DeviceList.php
+++ b/app/Livewire/DeviceList.php
@@ -10,6 +10,7 @@ use App\Models\Device;
 use App\Models\DeviceGroup;
 use App\Models\Strategy;
 use App\Models\User;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use Livewire\Attributes\Url;
 use Livewire\Component;
@@ -340,7 +341,7 @@ class DeviceList extends Component
 
         $devices = $this->selectedDevices();
         foreach ($devices as $device) {
-            $device->delete();
+            Device::deleteWithStrategyContext($device);
             ConsoleAudit::record('device.delete', 'Deleted device '.$device->rustdesk_id, 'device', $device->rustdesk_id);
         }
 
@@ -411,19 +412,15 @@ class DeviceList extends Component
 
         $targetId = $group?->id;
         $targetName = $group?->name ?? 'No group';
-        $moved = 0;
-        $unchanged = 0;
-
-        foreach ($devices as $device) {
-            if ((int) $device->device_group_id === (int) $targetId) {
-                $unchanged++;
-
-                continue;
-            }
-
-            $device->update(['device_group_id' => $targetId]);
-            $moved++;
-        }
+        $changedIds = $devices
+            ->filter(fn (Device $device) => (int) $device->device_group_id !== (int) $targetId)
+            ->pluck('id')->all();
+        $moved = Device::bulkUpdateStrategyContext(
+            Device::query()->whereKey($changedIds ?: [0]),
+            ['device_group_id' => $targetId],
+            auth()->user()->consoleAllows('strategy', 'rw'),
+        );
+        $unchanged = $devices->count() - $moved;
 
         if ($moved > 0) {
             ConsoleAudit::record(
@@ -564,7 +561,7 @@ class DeviceList extends Component
         $this->authorizeConsole('device', 'rw');
 
         $device = $this->scopedPendingDevice($id);
-        $device->update(['status' => Device::STATUS_ACTIVE]);
+        $device = Device::updateWithStrategyContext($device, ['status' => Device::STATUS_ACTIVE]);
         ConsoleAudit::record('device.approve', 'Approved device '.$device->rustdesk_id, 'device', $device->rustdesk_id);
     }
 
@@ -574,7 +571,7 @@ class DeviceList extends Component
 
         $device = $this->scopedPendingDevice($id);
         $rustdeskId = $device->rustdesk_id;
-        $device->delete(); // reject = soft-delete (quarantined + removed)
+        Device::deleteWithStrategyContext($device); // reject = soft-delete (quarantined + removed)
         ConsoleAudit::record('device.reject', 'Rejected device '.$rustdeskId, 'device', $rustdeskId);
     }
 
@@ -617,56 +614,39 @@ class DeviceList extends Component
             'user_id' => $data['formUserId'] ?: null,
         ];
 
+        $requestedStrategyId = (int) $data['formStrategyId'];
+        $currentStrategyId = $this->editingId === 0
+            ? 0
+            : (int) ($this->scopedDevice($this->editingId)->assignedStrategyId() ?? 0);
+        if ($requestedStrategyId !== $currentStrategyId) {
+            $this->addError(
+                'formStrategyId',
+                'Change direct strategy assignments from Strategies → Assign so the affected-device impact can be reviewed.',
+            );
+
+            return;
+        }
+
         if ($this->editingId === 0) {
             $this->validate(['formRustdeskId' => 'unique:devices,rustdesk_id']);
-            Device::create($attributes + [
+            Device::updateWithStrategyContext(new Device, $attributes + [
                 'rustdesk_id' => $data['formRustdeskId'],
                 'uuid' => '',
-            ]);
+            ], auth()->user()->consoleAllows('strategy', 'rw'));
             ConsoleAudit::record('device.create', 'Created device '.$data['formRustdeskId'], 'device', $data['formRustdeskId']);
         } else {
             $device = $this->scopedDevice($this->editingId);
-            $device->update($attributes);
+            DB::transaction(function () use (&$device, $attributes): void {
+                $device = Device::updateWithStrategyContext(
+                    $device,
+                    $attributes,
+                    auth()->user()->consoleAllows('strategy', 'rw'),
+                );
+            });
             ConsoleAudit::record('device.update', 'Updated device '.$device->rustdesk_id, 'device', $device->rustdesk_id);
-
-            $this->saveStrategyAssignment($device, (int) $data['formStrategyId']);
         }
 
         $this->editingId = null;
-    }
-
-    /**
-     * Device-level strategy assignment from the editor (PLAN C4). Admin-only,
-     * and a no-op unless it actually changes: assignTo() recomputes the cached
-     * resolution and an unconditional call would audit "changed" for every save.
-     */
-    private function saveStrategyAssignment(Device $device, int $strategyId): void
-    {
-        if (! auth()->user()?->is_admin) {
-            return;
-        }
-
-        $current = (int) $device->assignedStrategyId();
-        if ($current === $strategyId) {
-            return;
-        }
-
-        if ($strategyId !== 0 && ! Strategy::whereKey($strategyId)->exists()) {
-            return; // stale option in a form left open while the strategy was deleted
-        }
-
-        Strategy::assignTo(Strategy::LEVEL_DEVICE, $device->id, $strategyId ?: null);
-
-        $name = $strategyId === 0
-            ? 'none (inherits)'
-            : (string) Strategy::whereKey($strategyId)->value('name');
-
-        ConsoleAudit::record(
-            'strategy.assign',
-            'Device '.$device->rustdesk_id.' strategy set to '.$name,
-            'device',
-            $device->rustdesk_id,
-        );
     }
 
     public function closeModal(): void
@@ -680,7 +660,7 @@ class DeviceList extends Component
 
         $device = $this->scopedDevice($id);
         $rustdeskId = $device->rustdesk_id;
-        $device->delete(); // soft delete → recycle bin
+        Device::deleteWithStrategyContext($device); // soft delete → recycle bin
         ConsoleAudit::record('device.delete', 'Deleted device '.$rustdeskId, 'device', $rustdeskId);
     }
 
@@ -689,7 +669,7 @@ class DeviceList extends Component
         $this->authorizeConsole('device', 'rw');
 
         $device = $this->scopedDevice($id);
-        $device->restore();
+        $device = Device::restoreWithStrategyContext($device);
         ConsoleAudit::record('device.restore', 'Restored device '.$device->rustdesk_id, 'device', $device->rustdesk_id);
     }
 
@@ -699,7 +679,7 @@ class DeviceList extends Component
 
         $device = $this->scopedDevice($id);
         $rustdeskId = $device->rustdesk_id;
-        $device->forceDelete();
+        Device::deleteWithStrategyContext($device, true);
         ConsoleAudit::record('device.destroy', 'Permanently deleted device '.$rustdeskId, 'device', $rustdeskId);
     }
 

--- a/app/Livewire/GroupList.php
+++ b/app/Livewire/GroupList.php
@@ -8,6 +8,7 @@ use App\Models\Device;
 use App\Models\DeviceGroup;
 use App\Models\GroupAccess;
 use App\Models\UserGroup;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\Rule;
 use Livewire\Attributes\Url;
 use Livewire\Component;
@@ -171,9 +172,15 @@ class GroupList extends Component
         if ($type === 'devices') {
             $group = DeviceGroup::findOrFail($id);
             $name = $group->name;
-            Device::where('device_group_id', $id)->update(['device_group_id' => null]);
-            GroupAccess::purgeFor(GroupAccess::TARGET_DEVICE_GROUP, $group->id);
-            $group->delete();
+            DB::transaction(function () use ($group, $id): void {
+                Device::bulkUpdateStrategyContext(
+                    Device::query()->where('device_group_id', $id),
+                    ['device_group_id' => null],
+                    auth()->user()->consoleAllows('strategy', 'rw'),
+                );
+                GroupAccess::purgeFor(GroupAccess::TARGET_DEVICE_GROUP, $group->id);
+                $group->delete();
+            });
         } else {
             $group = UserGroup::findOrFail($id);
             $name = $group->name;

--- a/app/Livewire/StrategyList.php
+++ b/app/Livewire/StrategyList.php
@@ -7,6 +7,7 @@ use App\Models\ConsoleAudit;
 use App\Models\Device;
 use App\Models\DeviceGroup;
 use App\Models\Strategy;
+use App\Models\StrategyRevision;
 use App\Models\User;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\Rule;
@@ -47,6 +48,14 @@ class StrategyList extends Component
 
     /** @var array<string,string> option key => form value ('' = not managed) */
     public array $formOptions = [];
+
+    public string $revisionNote = '';
+
+    public ?int $historyStrategyId = null;
+
+    public ?int $compareFromRevisionId = null;
+
+    public ?int $compareToRevisionId = null;
 
     /** Assignment editor state: strategy id, or null when closed. */
     public ?int $assigningId = null;
@@ -251,17 +260,49 @@ class StrategyList extends Component
             return;
         }
 
-        $strategy = $this->editingId ? Strategy::findOrFail($this->editingId) : new Strategy;
-        $strategy->fill([
-            'name' => $this->formName,
-            'note' => $this->formNote !== '' ? $this->formNote : null,
-            'enabled' => $this->formEnabled,
-            'is_default' => $this->formIsDefault,
-            'enforce' => $this->formEnforce,
-        ]);
-        $strategy->setOptions($options);
-        $creating = ! $strategy->exists;
-        $strategy->save();
+        $this->validate(['revisionNote' => ['nullable', 'string', 'max:500']]);
+
+        [$strategy, $creating] = DB::transaction(function () use ($options): array {
+            // A new default can displace another strategy. Serialize strategy
+            // writes and revision allocation in one stable lock order.
+            Strategy::query()->orderBy('id')->lockForUpdate()->get(['id']);
+            $strategy = $this->editingId
+                ? Strategy::query()->lockForUpdate()->findOrFail($this->editingId)
+                : new Strategy;
+            $displacedDefault = $this->formIsDefault
+                ? Strategy::query()->whereKeyNot($strategy->id ?: 0)->where('is_default', true)->lockForUpdate()->first()
+                : null;
+
+            $strategy->fill([
+                'name' => $this->formName,
+                'note' => $this->formNote !== '' ? $this->formNote : null,
+                'enabled' => $this->formEnabled,
+                'is_default' => $this->formIsDefault,
+                'enforce' => $this->formEnforce,
+            ]);
+            $strategy->setOptions($options);
+            $creating = ! $strategy->exists;
+            $strategy->save();
+
+            $revision = StrategyRevision::capture(
+                $strategy,
+                auth()->id(),
+                $this->revisionNote !== '' ? $this->revisionNote : ($creating ? 'Initial revision' : 'Saved from the strategy editor'),
+            );
+            $strategy->forceFill(['active_revision_id' => $revision->id])->saveQuietly();
+
+            if ($displacedDefault !== null) {
+                $displacedDefault->refresh();
+                $displacedRevision = StrategyRevision::capture(
+                    $displacedDefault,
+                    auth()->id(),
+                    'Default status moved to '.$strategy->name,
+                );
+                $displacedDefault->forceFill(['active_revision_id' => $displacedRevision->id])->saveQuietly();
+            }
+
+            return [$strategy, $creating];
+        });
 
         ConsoleAudit::record(
             $creating ? 'strategy.create' : 'strategy.update',
@@ -284,8 +325,15 @@ class StrategyList extends Component
     {
         $this->authorizeConsole('strategy', 'rw');
 
-        $strategy = Strategy::findOrFail($id);
-        $strategy->update(['enabled' => ! $strategy->enabled]);
+        $strategy = DB::transaction(function () use ($id): Strategy {
+            Strategy::query()->orderBy('id')->lockForUpdate()->get(['id']);
+            $strategy = Strategy::query()->lockForUpdate()->findOrFail($id);
+            $strategy->update(['enabled' => ! $strategy->enabled]);
+            $revision = StrategyRevision::capture($strategy, auth()->id(), 'Toggled enabled state');
+            $strategy->forceFill(['active_revision_id' => $revision->id])->saveQuietly();
+
+            return $strategy;
+        });
 
         ConsoleAudit::record(
             'strategy.toggle',
@@ -304,6 +352,95 @@ class StrategyList extends Component
         $strategy->delete(); // pivots cascade; the model hook re-resolves the fleet
 
         ConsoleAudit::record('strategy.delete', 'Deleted strategy '.$name, 'strategy', $name);
+    }
+
+    // -------------------------------------------------------------- history ---
+
+    public function showHistory(int $strategyId): void
+    {
+        $this->authorizeConsole('strategy', 'r');
+        $strategy = Strategy::findOrFail($strategyId);
+        $ids = $strategy->revisions()->orderBy('revision')->pluck('id');
+        $this->historyStrategyId = $strategy->id;
+        $this->compareFromRevisionId = $ids->count() > 1 ? (int) $ids->first() : null;
+        $this->compareToRevisionId = $ids->isNotEmpty() ? (int) $ids->last() : null;
+    }
+
+    public function closeHistory(): void
+    {
+        $this->reset('historyStrategyId', 'compareFromRevisionId', 'compareToRevisionId');
+        $this->resetValidation('history');
+    }
+
+    public function restoreRevision(int $revisionId): void
+    {
+        $this->authorizeConsole('strategy', 'rw');
+
+        $strategy = DB::transaction(function () use ($revisionId): Strategy {
+            $revision = StrategyRevision::query()->findOrFail($revisionId);
+            Strategy::query()->orderBy('id')->lockForUpdate()->get(['id']);
+            $strategy = Strategy::query()->lockForUpdate()->findOrFail($revision->strategy_id);
+            $revision = StrategyRevision::query()->lockForUpdate()->findOrFail($revisionId);
+            $snapshot = is_array($revision->snapshot) ? $revision->snapshot : [];
+            $displacedDefault = (bool) ($snapshot['is_default'] ?? false)
+                ? Strategy::query()->whereKeyNot($strategy->id)->where('is_default', true)->lockForUpdate()->first()
+                : null;
+
+            // Names are durable identities. Restore policy state, never a name
+            // which may now be used by another strategy.
+            $strategy->fill([
+                'note' => $snapshot['note'] ?? null,
+                'enabled' => (bool) ($snapshot['enabled'] ?? true),
+                'is_default' => (bool) ($snapshot['is_default'] ?? false),
+                'enforce' => (bool) ($snapshot['enforce'] ?? false),
+            ]);
+            $strategy->setOptions(is_array($snapshot['options'] ?? null) ? $snapshot['options'] : []);
+            $strategy->save();
+
+            $newRevision = StrategyRevision::capture($strategy, auth()->id(), 'Restored revision '.$revision->revision);
+            $strategy->forceFill(['active_revision_id' => $newRevision->id])->saveQuietly();
+
+            if ($displacedDefault !== null) {
+                $displacedDefault->refresh();
+                $displacedRevision = StrategyRevision::capture(
+                    $displacedDefault,
+                    auth()->id(),
+                    'Default status moved to '.$strategy->name.' by rollback',
+                );
+                $displacedDefault->forceFill(['active_revision_id' => $displacedRevision->id])->saveQuietly();
+            }
+
+            return $strategy;
+        });
+
+        ConsoleAudit::record('strategy.rollback', 'Restored an earlier revision of strategy '.$strategy->name, 'strategy', $strategy->name);
+    }
+
+    public function getHistoryStrategyProperty(): ?Strategy
+    {
+        return $this->historyStrategyId ? Strategy::find($this->historyStrategyId) : null;
+    }
+
+    public function getRevisionHistoryProperty()
+    {
+        return $this->historyStrategyId
+            ? StrategyRevision::query()->where('strategy_id', $this->historyStrategyId)->with('creator')->orderByDesc('revision')->get()
+            : collect();
+    }
+
+    /** @return array<int,array{key:string,before:mixed,after:mixed}> */
+    public function getRevisionComparisonProperty(): array
+    {
+        if (! $this->historyStrategyId || ! $this->compareFromRevisionId || ! $this->compareToRevisionId) {
+            return [];
+        }
+
+        $revisions = StrategyRevision::query()->where('strategy_id', $this->historyStrategyId)
+            ->whereIn('id', [$this->compareFromRevisionId, $this->compareToRevisionId])->get()->keyBy('id');
+
+        return $revisions->has($this->compareFromRevisionId) && $revisions->has($this->compareToRevisionId)
+            ? StrategyRevision::diffSnapshots($revisions[$this->compareFromRevisionId]->snapshot, $revisions[$this->compareToRevisionId]->snapshot)
+            : [];
     }
 
     // --------------------------------------------------------- assignments ---
@@ -460,6 +597,9 @@ class StrategyList extends Component
             'strategies' => $strategies,
             'catalog' => self::catalog(),
             'assigning' => $this->assigningId ? $strategies->firstWhere('id', $this->assigningId) : null,
+            'historyStrategy' => $this->historyStrategy,
+            'revisionHistory' => $this->revisionHistory,
+            'revisionComparison' => $this->revisionComparison,
         ] + $this->assignCandidates());
 
         // (assignCandidates() is only non-empty while the assignment modal is open)

--- a/app/Livewire/StrategyList.php
+++ b/app/Livewire/StrategyList.php
@@ -9,6 +9,8 @@ use App\Models\DeviceGroup;
 use App\Models\Strategy;
 use App\Models\StrategyRevision;
 use App\Models\User;
+use App\Services\StrategyAssignmentImpact;
+use App\Services\StrategyImpact;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\Rule;
 use Livewire\Component;
@@ -32,6 +34,8 @@ use Livewire\Component;
 class StrategyList extends Component
 {
     use AuthorizesConsole;
+
+    private const MAX_EDITOR_ASSIGNMENTS = 5000;
 
     /** Editor state: null = closed, 0 = creating, >0 = editing that strategy. */
     public ?int $editingId = null;
@@ -57,6 +61,17 @@ class StrategyList extends Component
 
     public ?int $compareToRevisionId = null;
 
+    public bool $previewing = false;
+
+    /** @var array<string,mixed> */
+    public array $impactPreview = [];
+
+    public ?string $previewFingerprint = null;
+
+    public ?int $pendingDeleteId = null;
+
+    public ?int $restoreRevisionId = null;
+
     /** Assignment editor state: strategy id, or null when closed. */
     public ?int $assigningId = null;
 
@@ -72,6 +87,13 @@ class StrategyList extends Component
 
     /** @var array<int,int|string> */
     public array $assignGroupIds = [];
+
+    public bool $assignPreviewing = false;
+
+    /** @var array<string,mixed> */
+    public array $assignmentImpact = [];
+
+    public ?string $assignmentFingerprint = null;
 
     /** Section titles + the apply-timing caveat that belongs to each group. */
     private const GROUP_META = [
@@ -220,67 +242,82 @@ class StrategyList extends Component
         }
     }
 
+    /** Existing Livewire callers enter the same mandatory review flow. */
     public function save(): void
     {
+        $this->previewSave();
+    }
+
+    public function previewSave(): void
+    {
         $this->authorizeConsole('strategy', 'rw');
-
-        $this->validate([
-            'formName' => [
-                'required', 'string', 'max:255',
-                Rule::unique('strategies', 'name')->ignore($this->editingId ?: 0),
-            ],
-            'formNote' => ['nullable', 'string', 'max:500'],
-        ], [], ['formName' => 'name', 'formNote' => 'note']);
-
-        // Range-check the numeric options here rather than letting
-        // sanitizeOptions() drop them silently — a value that vanishes without
-        // a word is how an operator ends up believing a policy is in force.
-        $options = [];
-        foreach ($this->formOptions as $key => $value) {
-            $spec = Strategy::OPTION_KEYS[$key] ?? null;
-            $value = is_string($value) ? trim($value) : '';
-
-            if ($spec === null || $value === '') {
-                continue; // unknown key, or "not managed by this strategy"
-            }
-
-            if ($spec['type'] === 'int' && ! (ctype_digit($value)
-                && (int) $value >= ($spec['min'] ?? 0)
-                && (int) $value <= ($spec['max'] ?? PHP_INT_MAX))) {
-                $this->addError('formOptions.'.$key, 'Enter a whole number between '
-                    .($spec['min'] ?? 0).' and '.($spec['max'] ?? PHP_INT_MAX).'.');
-
-                continue;
-            }
-
-            $options[$key] = $value;
-        }
-
-        if ($this->getErrorBag()->isNotEmpty()) {
+        $snapshot = $this->validatedFormSnapshot();
+        if ($snapshot === null) {
             return;
         }
 
-        $this->validate(['revisionNote' => ['nullable', 'string', 'max:500']]);
+        $strategy = $this->editingId ? Strategy::findOrFail($this->editingId) : null;
+        $this->impactPreview = StrategyImpact::preview(
+            $strategy,
+            $this->reviewedSnapshot($snapshot),
+            auth()->user()?->is_admin === true,
+        );
+        $this->previewFingerprint = $this->impactPreview['fingerprint'];
+        $this->previewing = true;
+    }
 
-        [$strategy, $creating] = DB::transaction(function () use ($options): array {
-            // A new default can displace another strategy. Serialize strategy
-            // writes and revision allocation in one stable lock order.
-            Strategy::query()->orderBy('id')->lockForUpdate()->get(['id']);
-            $strategy = $this->editingId
-                ? Strategy::query()->lockForUpdate()->findOrFail($this->editingId)
-                : new Strategy;
-            $displacedDefault = $this->formIsDefault
+    public function confirmSave(): void
+    {
+        $this->authorizeConsole('strategy', 'rw');
+        $snapshot = $this->validatedFormSnapshot();
+        if ($snapshot === null) {
+            return;
+        }
+        if (! $this->previewing || $this->previewFingerprint === null) {
+            $this->addError('preview', 'The strategy changed after the preview. Review the impact again.');
+
+            return;
+        }
+
+        $result = DB::transaction(function () use ($snapshot): ?array {
+            // The fingerprint covers every active-device routing input. Lock those
+            // rows before recomputing it, then mutate only if it still matches.
+            $this->lockImpactSource();
+            $strategy = $this->editingId ? Strategy::findOrFail($this->editingId) : new Strategy;
+            $impact = StrategyImpact::preview(
+                $strategy->exists ? $strategy : null,
+                $this->reviewedSnapshot($snapshot),
+                auth()->user()?->is_admin === true,
+            );
+            if (! hash_equals($this->previewFingerprint, $impact['fingerprint'])) {
+                $this->addError('preview', 'The strategy changed after the preview. Review the impact again.');
+
+                return null;
+            }
+
+            if ($this->pendingDeleteId !== null) {
+                if (! $strategy->exists || $strategy->id !== $this->pendingDeleteId) {
+                    $this->addError('preview', 'The deletion target changed after the preview. Review the impact again.');
+
+                    return null;
+                }
+                $strategy->delete(); // assignments are released by the model hook
+
+                return [$strategy, false, 'delete'];
+            }
+
+            $displacedDefault = $snapshot['is_default']
                 ? Strategy::query()->whereKeyNot($strategy->id ?: 0)->where('is_default', true)->lockForUpdate()->first()
                 : null;
 
             $strategy->fill([
-                'name' => $this->formName,
-                'note' => $this->formNote !== '' ? $this->formNote : null,
-                'enabled' => $this->formEnabled,
-                'is_default' => $this->formIsDefault,
-                'enforce' => $this->formEnforce,
+                'name' => $snapshot['name'],
+                'note' => $snapshot['note'],
+                'enabled' => $snapshot['enabled'],
+                'is_default' => $snapshot['is_default'],
+                'enforce' => $snapshot['enforce'],
             ]);
-            $strategy->setOptions($options);
+            $strategy->setOptions($snapshot['options']);
             $creating = ! $strategy->exists;
             $strategy->save();
 
@@ -301,18 +338,39 @@ class StrategyList extends Component
                 $displacedDefault->forceFill(['active_revision_id' => $displacedRevision->id])->saveQuietly();
             }
 
-            return [$strategy, $creating];
+            return [$strategy, $creating, $this->restoreRevisionId !== null ? 'restore' : 'save'];
         });
 
+        if ($result === null) {
+            return;
+        }
+
+        [$strategy, $creating, $action] = $result;
+        if ($action === 'delete') {
+            ConsoleAudit::record('strategy.delete', 'Deleted strategy '.$strategy->name, 'strategy', $strategy->name);
+            $this->closeModal();
+
+            return;
+        }
         ConsoleAudit::record(
-            $creating ? 'strategy.create' : 'strategy.update',
-            ($creating ? 'Created' : 'Updated').' strategy '.$strategy->name
+            $action === 'restore' ? 'strategy.rollback' : ($creating ? 'strategy.create' : 'strategy.update'),
+            ($action === 'restore' ? 'Restored' : ($creating ? 'Created' : 'Updated')).' strategy '.$strategy->name
                 .' ('.count($strategy->optionMap()).' option(s))',
             'strategy',
             $strategy->name,
         );
-
         $this->closeModal();
+    }
+
+    public function closePreview(): void
+    {
+        if ($this->pendingDeleteId !== null) {
+            $this->closeModal();
+
+            return;
+        }
+        $this->reset('previewing', 'impactPreview', 'previewFingerprint');
+        $this->resetValidation('preview');
     }
 
     public function closeModal(): void
@@ -325,33 +383,23 @@ class StrategyList extends Component
     {
         $this->authorizeConsole('strategy', 'rw');
 
-        $strategy = DB::transaction(function () use ($id): Strategy {
-            Strategy::query()->orderBy('id')->lockForUpdate()->get(['id']);
-            $strategy = Strategy::query()->lockForUpdate()->findOrFail($id);
-            $strategy->update(['enabled' => ! $strategy->enabled]);
-            $revision = StrategyRevision::capture($strategy, auth()->id(), 'Toggled enabled state');
-            $strategy->forceFill(['active_revision_id' => $revision->id])->saveQuietly();
-
-            return $strategy;
-        });
-
-        ConsoleAudit::record(
-            'strategy.toggle',
-            ($strategy->enabled ? 'Enabled' : 'Disabled').' strategy '.$strategy->name,
-            'strategy',
-            $strategy->name,
-        );
+        $strategy = Strategy::findOrFail($id);
+        $this->edit($strategy->id);
+        $this->formEnabled = ! $strategy->enabled;
+        if (! $this->formEnabled) {
+            $this->formIsDefault = false;
+        }
+        $this->previewSave();
     }
 
     public function deleteStrategy(int $id): void
     {
         $this->authorizeConsole('strategy', 'rw');
-
-        $strategy = Strategy::findOrFail($id);
-        $name = $strategy->name;
-        $strategy->delete(); // pivots cascade; the model hook re-resolves the fleet
-
-        ConsoleAudit::record('strategy.delete', 'Deleted strategy '.$name, 'strategy', $name);
+        $this->edit($id);
+        $this->pendingDeleteId = $id;
+        $this->formEnabled = false;
+        $this->formIsDefault = false;
+        $this->previewSave();
     }
 
     // -------------------------------------------------------------- history ---
@@ -376,44 +424,26 @@ class StrategyList extends Component
     {
         $this->authorizeConsole('strategy', 'rw');
 
-        $strategy = DB::transaction(function () use ($revisionId): Strategy {
-            $revision = StrategyRevision::query()->findOrFail($revisionId);
-            Strategy::query()->orderBy('id')->lockForUpdate()->get(['id']);
-            $strategy = Strategy::query()->lockForUpdate()->findOrFail($revision->strategy_id);
-            $revision = StrategyRevision::query()->lockForUpdate()->findOrFail($revisionId);
-            $snapshot = is_array($revision->snapshot) ? $revision->snapshot : [];
-            $displacedDefault = (bool) ($snapshot['is_default'] ?? false)
-                ? Strategy::query()->whereKeyNot($strategy->id)->where('is_default', true)->lockForUpdate()->first()
-                : null;
+        $revision = StrategyRevision::query()->findOrFail($revisionId);
+        $strategy = Strategy::findOrFail($revision->strategy_id);
+        $snapshot = is_array($revision->snapshot) ? $revision->snapshot : [];
 
-            // Names are durable identities. Restore policy state, never a name
-            // which may now be used by another strategy.
-            $strategy->fill([
-                'note' => $snapshot['note'] ?? null,
-                'enabled' => (bool) ($snapshot['enabled'] ?? true),
-                'is_default' => (bool) ($snapshot['is_default'] ?? false),
-                'enforce' => (bool) ($snapshot['enforce'] ?? false),
-            ]);
-            $strategy->setOptions(is_array($snapshot['options'] ?? null) ? $snapshot['options'] : []);
-            $strategy->save();
-
-            $newRevision = StrategyRevision::capture($strategy, auth()->id(), 'Restored revision '.$revision->revision);
-            $strategy->forceFill(['active_revision_id' => $newRevision->id])->saveQuietly();
-
-            if ($displacedDefault !== null) {
-                $displacedDefault->refresh();
-                $displacedRevision = StrategyRevision::capture(
-                    $displacedDefault,
-                    auth()->id(),
-                    'Default status moved to '.$strategy->name.' by rollback',
-                );
-                $displacedDefault->forceFill(['active_revision_id' => $displacedRevision->id])->saveQuietly();
+        $this->closeHistory();
+        $this->edit($strategy->id);
+        $this->restoreRevisionId = $revision->id;
+        $this->revisionNote = 'Restored revision '.$revision->revision;
+        // Names are durable identities. Review restoring policy state only.
+        $this->formNote = (string) ($snapshot['note'] ?? '');
+        $this->formEnabled = (bool) ($snapshot['enabled'] ?? true);
+        $this->formIsDefault = (bool) ($snapshot['is_default'] ?? false);
+        $this->formEnforce = (bool) ($snapshot['enforce'] ?? false);
+        $this->formOptions = array_fill_keys(array_keys($this->formOptions), '');
+        foreach ((array) ($snapshot['options'] ?? []) as $key => $value) {
+            if (array_key_exists($key, $this->formOptions)) {
+                $this->formOptions[$key] = (string) $value;
             }
-
-            return $strategy;
-        });
-
-        ConsoleAudit::record('strategy.rollback', 'Restored an earlier revision of strategy '.$strategy->name, 'strategy', $strategy->name);
+        }
+        $this->previewSave();
     }
 
     public function getHistoryStrategyProperty(): ?Strategy
@@ -448,10 +478,12 @@ class StrategyList extends Component
     public function openAssign(int $id): void
     {
         $this->authorizeConsole('strategy', 'rw');
+        $this->authorizeFleetAssignments();
 
         $strategy = Strategy::findOrFail($id);
 
         $this->assigningId = $strategy->id;
+        $this->reset('assignPreviewing', 'assignmentImpact', 'assignmentFingerprint');
         $this->assignTab = 'devices';
         $this->assignSearch = '';
         $this->assignDeviceIds = $strategy->devices()->pluck('devices.id')->all();
@@ -461,31 +493,109 @@ class StrategyList extends Component
 
     public function setAssignTab(string $tab): void
     {
+        $this->authorizeConsole('strategy', 'rw');
+        $this->authorizeFleetAssignments();
+
         if (in_array($tab, ['devices', 'users', 'groups'], true)) {
             $this->assignTab = $tab;
             $this->assignSearch = '';
         }
     }
 
+    /** Existing Livewire callers enter the same mandatory review flow. */
     public function saveAssign(): void
     {
+        $this->authorizeFleetAssignments();
+        $this->previewAssign();
+    }
+
+    public function previewAssign(): void
+    {
         $this->authorizeConsole('strategy', 'rw');
-
+        $this->authorizeFleetAssignments();
         $strategy = Strategy::findOrFail($this->assigningId);
+        if (! $this->validateAssignmentIds()) {
+            return;
+        }
 
-        $this->validate([
-            'assignDeviceIds.*' => [Rule::exists('devices', 'id')],
-            'assignUserIds.*' => [Rule::exists('users', 'id')],
-            'assignGroupIds.*' => [Rule::exists('device_groups', 'id')],
-        ]);
+        $this->assignmentImpact = StrategyAssignmentImpact::preview(
+            $strategy,
+            $this->assignDeviceIds,
+            $this->assignUserIds,
+            $this->assignGroupIds,
+        );
+        $this->assignmentFingerprint = $this->assignmentImpact['fingerprint'];
+        $this->assignPreviewing = true;
+    }
 
-        $changed = 0;
-        $changed += $this->syncLevel($strategy, Strategy::LEVEL_DEVICE,
-            $strategy->devices()->pluck('devices.id')->all(), $this->assignDeviceIds);
-        $changed += $this->syncLevel($strategy, Strategy::LEVEL_USER,
-            $strategy->users()->pluck('users.id')->all(), $this->assignUserIds);
-        $changed += $this->syncLevel($strategy, Strategy::LEVEL_DEVICE_GROUP,
-            $strategy->deviceGroups()->pluck('device_groups.id')->all(), $this->assignGroupIds);
+    public function confirmAssign(): void
+    {
+        $this->authorizeConsole('strategy', 'rw');
+        $this->authorizeFleetAssignments();
+        $strategy = Strategy::findOrFail($this->assigningId);
+        if (! $this->validateAssignmentIds()) {
+            return;
+        }
+        if (! $this->assignPreviewing || $this->assignmentFingerprint === null) {
+            $this->addError('assignment', 'Assignments changed after the preview. Review the impact again.');
+
+            return;
+        }
+
+        $changed = DB::transaction(function () use ($strategy): ?int {
+            // Assignment writers lock the strategy set first, then only the
+            // current and desired targets in stable order.
+            Strategy::query()->orderBy('id')->lockForUpdate()->get(['id']);
+            $currentAssignments = [
+                Strategy::LEVEL_DEVICE => DB::table('device_strategy')->where('strategy_id', $strategy->id)->pluck('device_id')->map(fn ($id) => (int) $id)->all(),
+                Strategy::LEVEL_USER => DB::table('strategy_user')->where('strategy_id', $strategy->id)->pluck('user_id')->map(fn ($id) => (int) $id)->all(),
+                Strategy::LEVEL_DEVICE_GROUP => DB::table('device_group_strategy')->where('strategy_id', $strategy->id)->pluck('device_group_id')->map(fn ($id) => (int) $id)->all(),
+            ];
+            $desiredAssignments = [
+                Strategy::LEVEL_DEVICE => array_map('intval', $this->assignDeviceIds),
+                Strategy::LEVEL_USER => array_map('intval', $this->assignUserIds),
+                Strategy::LEVEL_DEVICE_GROUP => array_map('intval', $this->assignGroupIds),
+            ];
+            Device::withTrashed()->whereIn('id', array_values(array_unique([
+                ...$currentAssignments[Strategy::LEVEL_DEVICE],
+                ...$desiredAssignments[Strategy::LEVEL_DEVICE],
+            ])))->orderBy('id')->lockForUpdate()->get(['id']);
+            User::query()->whereIn('id', array_values(array_unique([
+                ...$currentAssignments[Strategy::LEVEL_USER],
+                ...$desiredAssignments[Strategy::LEVEL_USER],
+            ])))->orderBy('id')->lockForUpdate()->get(['id']);
+            DeviceGroup::query()->whereIn('id', array_values(array_unique([
+                ...$currentAssignments[Strategy::LEVEL_DEVICE_GROUP],
+                ...$desiredAssignments[Strategy::LEVEL_DEVICE_GROUP],
+            ])))->orderBy('id')->lockForUpdate()->get(['id']);
+
+            $strategy = Strategy::findOrFail($strategy->id);
+            $impact = StrategyAssignmentImpact::preview(
+                $strategy,
+                $this->assignDeviceIds,
+                $this->assignUserIds,
+                $this->assignGroupIds,
+            );
+            if (! hash_equals($this->assignmentFingerprint, $impact['fingerprint'])) {
+                $this->addError('assignment', 'Assignments changed after the preview. Review the impact again.');
+
+                return null;
+            }
+
+            $changed = 0;
+            $changed += $this->syncLevel($strategy, Strategy::LEVEL_DEVICE,
+                $currentAssignments[Strategy::LEVEL_DEVICE], $this->assignDeviceIds);
+            $changed += $this->syncLevel($strategy, Strategy::LEVEL_USER,
+                $currentAssignments[Strategy::LEVEL_USER], $this->assignUserIds);
+            $changed += $this->syncLevel($strategy, Strategy::LEVEL_DEVICE_GROUP,
+                $currentAssignments[Strategy::LEVEL_DEVICE_GROUP], $this->assignGroupIds);
+
+            return $changed;
+        });
+
+        if ($changed === null) {
+            return;
+        }
 
         ConsoleAudit::record(
             'strategy.assign',
@@ -497,8 +607,33 @@ class StrategyList extends Component
             'strategy',
             $strategy->name,
         );
-
         $this->closeAssign();
+    }
+
+    public function closeAssignPreview(): void
+    {
+        $this->reset('assignPreviewing', 'assignmentImpact', 'assignmentFingerprint');
+        $this->resetValidation('assignment');
+    }
+
+    private function validateAssignmentIds(): bool
+    {
+        $this->validate([
+            'assignDeviceIds' => ['array', 'max:'.self::MAX_EDITOR_ASSIGNMENTS],
+            'assignDeviceIds.*' => [Rule::exists('devices', 'id')],
+            'assignUserIds' => ['array', 'max:'.self::MAX_EDITOR_ASSIGNMENTS],
+            'assignUserIds.*' => [Rule::exists('users', 'id')],
+            'assignGroupIds' => ['array', 'max:'.self::MAX_EDITOR_ASSIGNMENTS],
+            'assignGroupIds.*' => [Rule::exists('device_groups', 'id')],
+        ]);
+
+        if (count($this->assignDeviceIds) + count($this->assignUserIds) + count($this->assignGroupIds) > self::MAX_EDITOR_ASSIGNMENTS) {
+            $this->addError('assignment', 'Keep the interactive assignment set at 5,000 targets or fewer.');
+
+            return false;
+        }
+
+        return true;
     }
 
     /**
@@ -533,16 +668,101 @@ class StrategyList extends Component
     public function closeAssign(): void
     {
         $this->assigningId = null;
-        $this->reset('assignTab', 'assignSearch', 'assignDeviceIds', 'assignUserIds', 'assignGroupIds');
+        $this->reset(
+            'assignTab', 'assignSearch', 'assignDeviceIds', 'assignUserIds', 'assignGroupIds',
+            'assignPreviewing', 'assignmentImpact', 'assignmentFingerprint',
+        );
+        $this->resetValidation(['assignDeviceIds', 'assignUserIds', 'assignGroupIds', 'assignment']);
     }
 
     // -------------------------------------------------------------- render ---
 
     private function resetForm(): void
     {
-        $this->reset('formName', 'formNote', 'formEnabled', 'formIsDefault', 'formEnforce');
+        $this->reset(
+            'formName', 'formNote', 'formEnabled', 'formIsDefault', 'formEnforce', 'revisionNote',
+            'previewing', 'impactPreview', 'previewFingerprint', 'pendingDeleteId', 'restoreRevisionId',
+        );
         $this->resetValidation();
         $this->formOptions = array_fill_keys(array_keys(Strategy::OPTION_KEYS), '');
+    }
+
+    /** Bind the reviewed action itself into the stale-confirmation fingerprint. */
+    private function reviewedSnapshot(array $snapshot): array
+    {
+        return $snapshot + [
+            'operation' => $this->pendingDeleteId !== null ? 'delete' : ($this->restoreRevisionId !== null ? 'restore' : 'save'),
+            'restore_revision_id' => $this->restoreRevisionId,
+        ];
+    }
+
+    /** @return array{name:string,note:?string,enabled:bool,is_default:bool,enforce:bool,options:array<string,string>}|null */
+    private function validatedFormSnapshot(): ?array
+    {
+        $this->validate([
+            'formName' => [
+                'required', 'string', 'max:255',
+                Rule::unique('strategies', 'name')->ignore($this->editingId ?: 0),
+            ],
+            'formNote' => ['nullable', 'string', 'max:500'],
+            'revisionNote' => ['nullable', 'string', 'max:500'],
+        ], [], ['formName' => 'name', 'formNote' => 'note']);
+
+        if ($this->formIsDefault && ! $this->formEnabled) {
+            $this->addError('formIsDefault', 'The default strategy must be enabled.');
+        }
+
+        $options = [];
+        foreach ($this->formOptions as $key => $value) {
+            $spec = Strategy::OPTION_KEYS[$key] ?? null;
+            $value = is_string($value) ? trim($value) : '';
+            if ($spec === null || $value === '') {
+                continue;
+            }
+            if ($spec['type'] === 'bool' && ! in_array($value, ['Y', 'N'], true)) {
+                $this->addError('formOptions.'.$key, 'Choose Enabled, Disabled, or Not managed.');
+
+                continue;
+            }
+            if ($spec['type'] === 'enum' && ! in_array($value, $spec['values'] ?? [], true)) {
+                $this->addError('formOptions.'.$key, 'Choose one of the supported values.');
+
+                continue;
+            }
+            if ($spec['type'] === 'string' && mb_strlen($value) > 4096) {
+                $this->addError('formOptions.'.$key, 'Keep this setting under 4,096 characters.');
+
+                continue;
+            }
+            if ($spec['type'] === 'int' && ! (ctype_digit($value)
+                && (int) $value >= ($spec['min'] ?? 0)
+                && (int) $value <= ($spec['max'] ?? PHP_INT_MAX))) {
+                $this->addError('formOptions.'.$key, 'Enter a whole number between '
+                    .($spec['min'] ?? 0).' and '.($spec['max'] ?? PHP_INT_MAX).'.');
+
+                continue;
+            }
+            $options[$key] = $value;
+        }
+
+        if ($this->getErrorBag()->isNotEmpty()) {
+            return null;
+        }
+
+        return [
+            'name' => $this->formName,
+            'note' => $this->formNote !== '' ? $this->formNote : null,
+            'enabled' => $this->formEnabled,
+            'is_default' => $this->formIsDefault,
+            'enforce' => $this->formEnforce,
+            'options' => $options,
+        ];
+    }
+
+    /** Serialize confirm-time recomputation with every fleet-policy writer. */
+    private function lockImpactSource(): void
+    {
+        Strategy::query()->orderBy('id')->lockForUpdate()->get(['id']);
     }
 
     /**
@@ -596,7 +816,10 @@ class StrategyList extends Component
         return view('livewire.strategy-list', [
             'strategies' => $strategies,
             'catalog' => self::catalog(),
-            'assigning' => $this->assigningId ? $strategies->firstWhere('id', $this->assigningId) : null,
+            'canAssignFleet' => auth()->user()?->is_admin === true,
+            'assigning' => auth()->user()?->is_admin === true && $this->assigningId
+                ? $strategies->firstWhere('id', $this->assigningId)
+                : null,
             'historyStrategy' => $this->historyStrategy,
             'revisionHistory' => $this->revisionHistory,
             'revisionComparison' => $this->revisionComparison,
@@ -617,7 +840,7 @@ class StrategyList extends Component
     {
         $empty = ['assignDevices' => collect(), 'assignUsers' => collect(), 'assignGroups' => collect(), 'assignTaken' => []];
 
-        if ($this->assigningId === null) {
+        if (auth()->user()?->is_admin !== true || $this->assigningId === null) {
             return $empty;
         }
 
@@ -664,5 +887,11 @@ class StrategyList extends Component
             ->whereIn($table.'.'.$column, $ids)
             ->pluck('strategies.name', $table.'.'.$column)
             ->all();
+    }
+
+    /** Fleet-wide assignment intentionally remains a super-admin operation. */
+    private function authorizeFleetAssignments(): void
+    {
+        abort_unless(auth()->user()?->is_admin === true, 403);
     }
 }

--- a/app/Livewire/StrategyList.php
+++ b/app/Livewire/StrategyList.php
@@ -8,9 +8,11 @@ use App\Models\Device;
 use App\Models\DeviceGroup;
 use App\Models\Strategy;
 use App\Models\StrategyRevision;
+use App\Models\StrategyRollout;
 use App\Models\User;
 use App\Services\StrategyAssignmentImpact;
 use App\Services\StrategyImpact;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\Rule;
 use Livewire\Component;
@@ -50,6 +52,8 @@ class StrategyList extends Component
 
     public bool $formEnforce = false;
 
+    public int $formConfirmationTimeout = 15;
+
     /** @var array<string,string> option key => form value ('' = not managed) */
     public array $formOptions = [];
 
@@ -67,6 +71,12 @@ class StrategyList extends Component
     public array $impactPreview = [];
 
     public ?string $previewFingerprint = null;
+
+    public int $rolloutBatchSize = 100;
+
+    public int $rolloutIntervalMinutes = 5;
+
+    public string $rolloutStartAt = '';
 
     public ?int $pendingDeleteId = null;
 
@@ -234,6 +244,7 @@ class StrategyList extends Component
         $this->formEnabled = (bool) $strategy->enabled;
         $this->formIsDefault = (bool) $strategy->is_default;
         $this->formEnforce = (bool) $strategy->enforce;
+        $this->formConfirmationTimeout = (int) $strategy->confirmation_timeout_minutes;
 
         foreach ($strategy->optionMap() as $key => $value) {
             if (array_key_exists($key, $this->formOptions)) {
@@ -284,6 +295,7 @@ class StrategyList extends Component
             // rows before recomputing it, then mutate only if it still matches.
             $this->lockImpactSource();
             $strategy = $this->editingId ? Strategy::findOrFail($this->editingId) : new Strategy;
+            Strategy::guardNoOpenPolicyChanges();
             $impact = StrategyImpact::preview(
                 $strategy->exists ? $strategy : null,
                 $this->reviewedSnapshot($snapshot),
@@ -316,6 +328,7 @@ class StrategyList extends Component
                 'enabled' => $snapshot['enabled'],
                 'is_default' => $snapshot['is_default'],
                 'enforce' => $snapshot['enforce'],
+                'confirmation_timeout_minutes' => $snapshot['confirmation_timeout_minutes'],
             ]);
             $strategy->setOptions($snapshot['options']);
             $creating = ! $strategy->exists;
@@ -360,6 +373,113 @@ class StrategyList extends Component
             $strategy->name,
         );
         $this->closeModal();
+    }
+
+    public function scheduleRollout(): void
+    {
+        $this->authorizeConsole('strategy', 'rw');
+        $this->authorizeFleetAssignments();
+        $this->validate([
+            'rolloutBatchSize' => ['required', 'integer', 'min:1', 'max:1000'],
+            'rolloutIntervalMinutes' => ['required', 'integer', 'min:1', 'max:1440'],
+            'rolloutStartAt' => ['nullable', 'date'],
+        ]);
+        if (! $this->editingId || $this->pendingDeleteId !== null || $this->restoreRevisionId !== null) {
+            $this->addError('rollout', 'Only a reviewed update to an existing strategy can be staged.');
+
+            return;
+        }
+        $snapshot = $this->validatedFormSnapshot();
+        if ($snapshot === null || ! $this->previewing || $this->previewFingerprint === null) {
+            $this->addError('rollout', 'Review the strategy impact before scheduling a rollout.');
+
+            return;
+        }
+
+        $rollout = DB::transaction(function () use ($snapshot): ?StrategyRollout {
+            $this->lockImpactSource();
+            $strategy = Strategy::findOrFail($this->editingId);
+            Strategy::guardNoOpenRollouts([$strategy->id]);
+            $impact = StrategyImpact::preview($strategy, $this->reviewedSnapshot($snapshot), true);
+            if (! hash_equals($this->previewFingerprint, $impact['fingerprint'])) {
+                $this->addError('rollout', 'The fleet changed after the preview. Review the impact again.');
+
+                return null;
+            }
+            if ((int) $impact['affected_count'] === 0) {
+                $this->addError('rollout', 'No active devices need this policy change; apply the metadata update now instead.');
+
+                return null;
+            }
+
+            $revision = StrategyRevision::captureSnapshot(
+                $strategy,
+                $snapshot,
+                auth()->id(),
+                $this->revisionNote !== '' ? $this->revisionNote : 'Scheduled staged rollout',
+                (int) $impact['affected_count'],
+            );
+            $startAt = $this->rolloutStartAt !== ''
+                ? Carbon::parse($this->rolloutStartAt, config('app.timezone'))
+                : now();
+            if ($startAt->isPast()) {
+                $startAt = now();
+            }
+
+            return StrategyRollout::schedule(
+                $strategy,
+                $revision,
+                StrategyImpact::affectedDeviceIds($strategy, $snapshot),
+                $startAt,
+                $this->rolloutBatchSize,
+                $this->rolloutIntervalMinutes,
+                auth()->id(),
+            );
+        });
+        if ($rollout === null) {
+            return;
+        }
+
+        ConsoleAudit::record(
+            'strategy.rollout.schedule',
+            'Scheduled rollout #'.$rollout->id.' for '.$rollout->strategy->name.' ('.$rollout->target_count.' devices)',
+            'strategy',
+            $rollout->strategy->name,
+        );
+        $this->closeModal();
+    }
+
+    public function pauseRollout(int $rolloutId): void
+    {
+        $this->authorizeRolloutAction();
+        $rollout = StrategyRollout::findOrFail($rolloutId);
+        if ($rollout->pause(auth()->id())) {
+            ConsoleAudit::record('strategy.rollout.pause', 'Paused rollout #'.$rollout->id, 'strategy', (string) $rollout->strategy_id);
+        }
+    }
+
+    public function resumeRollout(int $rolloutId): void
+    {
+        $this->authorizeRolloutAction();
+        $rollout = StrategyRollout::findOrFail($rolloutId);
+        if ($rollout->resume()) {
+            ConsoleAudit::record('strategy.rollout.resume', 'Resumed rollout #'.$rollout->id, 'strategy', (string) $rollout->strategy_id);
+        }
+    }
+
+    public function cancelRollout(int $rolloutId): void
+    {
+        $this->authorizeRolloutAction();
+        $rollout = StrategyRollout::findOrFail($rolloutId);
+        if ($rollout->cancel(auth()->id())) {
+            ConsoleAudit::record('strategy.rollout.cancel', 'Cancelled rollout #'.$rollout->id, 'strategy', (string) $rollout->strategy_id);
+        }
+    }
+
+    private function authorizeRolloutAction(): void
+    {
+        $this->authorizeConsole('strategy', 'rw');
+        $this->authorizeFleetAssignments();
     }
 
     public function closePreview(): void
@@ -437,6 +557,7 @@ class StrategyList extends Component
         $this->formEnabled = (bool) ($snapshot['enabled'] ?? true);
         $this->formIsDefault = (bool) ($snapshot['is_default'] ?? false);
         $this->formEnforce = (bool) ($snapshot['enforce'] ?? false);
+        $this->formConfirmationTimeout = (int) ($snapshot['confirmation_timeout_minutes'] ?? $strategy->confirmation_timeout_minutes);
         $this->formOptions = array_fill_keys(array_keys($this->formOptions), '');
         foreach ((array) ($snapshot['options'] ?? []) as $key => $value) {
             if (array_key_exists($key, $this->formOptions)) {
@@ -680,8 +801,9 @@ class StrategyList extends Component
     private function resetForm(): void
     {
         $this->reset(
-            'formName', 'formNote', 'formEnabled', 'formIsDefault', 'formEnforce', 'revisionNote',
+            'formName', 'formNote', 'formEnabled', 'formIsDefault', 'formEnforce', 'formConfirmationTimeout', 'revisionNote',
             'previewing', 'impactPreview', 'previewFingerprint', 'pendingDeleteId', 'restoreRevisionId',
+            'rolloutBatchSize', 'rolloutIntervalMinutes', 'rolloutStartAt',
         );
         $this->resetValidation();
         $this->formOptions = array_fill_keys(array_keys(Strategy::OPTION_KEYS), '');
@@ -696,7 +818,7 @@ class StrategyList extends Component
         ];
     }
 
-    /** @return array{name:string,note:?string,enabled:bool,is_default:bool,enforce:bool,options:array<string,string>}|null */
+    /** @return array{name:string,note:?string,enabled:bool,is_default:bool,enforce:bool,confirmation_timeout_minutes:int,options:array<string,string>}|null */
     private function validatedFormSnapshot(): ?array
     {
         $this->validate([
@@ -706,6 +828,7 @@ class StrategyList extends Component
             ],
             'formNote' => ['nullable', 'string', 'max:500'],
             'revisionNote' => ['nullable', 'string', 'max:500'],
+            'formConfirmationTimeout' => ['required', 'integer', 'min:1', 'max:1440'],
         ], [], ['formName' => 'name', 'formNote' => 'note']);
 
         if ($this->formIsDefault && ! $this->formEnabled) {
@@ -755,6 +878,7 @@ class StrategyList extends Component
             'enabled' => $this->formEnabled,
             'is_default' => $this->formIsDefault,
             'enforce' => $this->formEnforce,
+            'confirmation_timeout_minutes' => $this->formConfirmationTimeout,
             'options' => $options,
         ];
     }
@@ -817,6 +941,16 @@ class StrategyList extends Component
             'strategies' => $strategies,
             'catalog' => self::catalog(),
             'canAssignFleet' => auth()->user()?->is_admin === true,
+            'rollouts' => auth()->user()?->is_admin === true
+                ? StrategyRollout::query()->with(['strategy', 'revision'])
+                    ->withCount([
+                        'targets',
+                        'targets as released_count' => fn ($q) => $q->whereNotNull('released_at'),
+                        'targets as confirmed_count' => fn ($q) => $q->whereNotNull('confirmed_at'),
+                        'targets as timed_out_count' => fn ($q) => $q->whereNotNull('timed_out_at'),
+                    ])
+                    ->latest()->limit(20)->get()
+                : collect(),
             'assigning' => auth()->user()?->is_admin === true && $this->assigningId
                 ? $strategies->firstWhere('id', $this->assigningId)
                 : null,

--- a/app/Livewire/UserList.php
+++ b/app/Livewire/UserList.php
@@ -6,10 +6,8 @@ use App\Livewire\Concerns\AuthorizesConsole;
 use App\Models\ConsoleAudit;
 use App\Models\Device;
 use App\Models\Role;
-use App\Models\Strategy;
 use App\Models\User;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Str;
 use Illuminate\Validation\Rule;
 use Livewire\Attributes\Url;
 use Livewire\Component;
@@ -354,9 +352,15 @@ class UserList extends Component
         $this->guardTarget($user);
         $username = $user->username;
 
-        // Keep the devices, just detach them from the deleted owner.
-        $user->devices()->update(['user_id' => null]);
-        $user->delete();
+        DB::transaction(function () use ($user): void {
+            // Keep the devices, just detach them from the deleted owner.
+            Device::bulkUpdateStrategyContext(
+                Device::query()->where('user_id', $user->id),
+                ['user_id' => null],
+                auth()->user()->consoleAllows('strategy', 'rw'),
+            );
+            $user->delete();
+        });
 
         ConsoleAudit::record('user.delete', 'Deleted user '.$username, 'user', $username);
     }
@@ -408,19 +412,22 @@ class UserList extends Component
             ->whereIn('id', array_map('intval', $this->assignDeviceIds))
             ->pluck('id')->map(fn ($id) => (int) $id)->all();
 
-        // Devices to gain this owner, and this user's current devices to release
-        // — the release is scoped too, or a delegated actor could orphan devices
-        // they cannot see just by opening the modal and saving.
-        Device::whereIn('id', $ids)->update(['user_id' => $user->id]);
-        $this->assignableDevices()
-            ->where('user_id', $user->id)
-            ->whereNotIn('id', $ids ?: [0])
-            ->update(['user_id' => null]);
-
-        // Both updates above are query-builder writes, so no model event fired
-        // and the cached strategy resolution (PLAN C2) is now stale for every
-        // device that changed hands. Rebuild it.
-        Strategy::recomputeAll();
+        DB::transaction(function () use ($ids, $user): void {
+            // Devices to gain this owner, and this user's current devices to
+            // release. Both paths share the impact-confirmation lock boundary.
+            Device::bulkUpdateStrategyContext(
+                Device::query()->whereIn('id', $ids ?: [0]),
+                ['user_id' => $user->id],
+                auth()->user()->consoleAllows('strategy', 'rw'),
+            );
+            Device::bulkUpdateStrategyContext(
+                $this->assignableDevices()
+                    ->where('user_id', $user->id)
+                    ->whereNotIn('id', $ids ?: [0]),
+                ['user_id' => null],
+                auth()->user()->consoleAllows('strategy', 'rw'),
+            );
+        });
 
         ConsoleAudit::record(
             'user.assign-devices',

--- a/app/Models/Device.php
+++ b/app/Models/Device.php
@@ -2,10 +2,12 @@
 
 namespace App\Models;
 
+use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Facades\DB;
 
 class Device extends Model
 {
@@ -83,6 +85,140 @@ class Device extends Model
             if ($device->wasChanged(['user_id', 'device_group_id'])) {
                 Strategy::syncResolvedFor($device);
             }
+        });
+    }
+
+    /**
+     * Update a device through the strategy-resolution boundary. Owner/group
+     * changes acquire the same strategy lock as impact confirmation, so the
+     * reviewed fleet state cannot change during confirm-time recomputation.
+     *
+     * @param  array<string,mixed>  $attributes
+     */
+    public static function updateWithStrategyContext(
+        Device $device,
+        array $attributes,
+        bool $mayChangeResolvedStrategy = true,
+    ): Device {
+        $touchesContext = ! $device->exists
+            || array_key_exists('status', $attributes)
+            || array_key_exists('user_id', $attributes)
+            || array_key_exists('device_group_id', $attributes);
+
+        return DB::transaction(function () use ($device, $attributes, $touchesContext, $mayChangeResolvedStrategy): Device {
+            if ($touchesContext) {
+                Strategy::query()->orderBy('id')->lockForUpdate()->get(['id']);
+            }
+
+            $locked = $device->exists
+                ? static::withTrashed()->whereKey($device->getKey())->lockForUpdate()->firstOrFail()
+                : $device;
+            $beforeResolution = $touchesContext ? Strategy::resolve($locked) : null;
+            $locked->fill($attributes);
+
+            if ($touchesContext
+                && $locked->isDirty(['user_id', 'device_group_id'])
+                && ! $mayChangeResolvedStrategy
+                && $beforeResolution !== Strategy::resolve($locked)) {
+                throw new AuthorizationException('Changing device ownership or group would change its effective strategy and requires strategy write permission.');
+            }
+
+            $locked->save();
+
+            return $locked;
+        });
+    }
+
+    /**
+     * Apply one owner/group change to a bounded set of existing devices through
+     * the same serialized resolution boundary.
+     *
+     * @param  array{user_id?:?int,device_group_id?:?int}  $attributes
+     */
+    public static function bulkUpdateStrategyContext(
+        Builder $scope,
+        array $attributes,
+        bool $mayChangeResolvedStrategy = true,
+    ): int {
+        $attributes = array_intersect_key($attributes, array_flip(['user_id', 'device_group_id']));
+        if ($attributes === []) {
+            return 0;
+        }
+
+        return DB::transaction(function () use ($scope, $attributes, $mayChangeResolvedStrategy): int {
+            Strategy::query()->orderBy('id')->lockForUpdate()->get(['id']);
+            $changedScope = (clone $scope)->where(function (Builder $dirty) use ($attributes): void {
+                $first = true;
+                foreach ($attributes as $column => $desired) {
+                    $method = $first ? 'where' : 'orWhere';
+                    $dirty->{$method}(function (Builder $columnQuery) use ($column, $desired): void {
+                        $qualified = 'devices.'.$column;
+                        if ($desired === null) {
+                            $columnQuery->whereNotNull($qualified);
+                        } else {
+                            $columnQuery->whereNull($qualified)->orWhere($qualified, '!=', $desired);
+                        }
+                    });
+                    $first = false;
+                }
+            });
+
+            $changedCount = 0;
+            $lastId = 0;
+            do {
+                $ids = (clone $changedScope)
+                    ->where('devices.id', '>', $lastId)
+                    ->reorder('devices.id')
+                    ->limit(500)
+                    ->lockForUpdate()
+                    ->pluck('devices.id')
+                    ->map(fn ($id) => (int) $id)
+                    ->all();
+                if ($ids === []) {
+                    break;
+                }
+
+                if (! $mayChangeResolvedStrategy) {
+                    static::query()->whereKey($ids)->orderBy('id')->each(function (Device $current) use ($attributes): void {
+                        $candidate = clone $current;
+                        $candidate->fill($attributes);
+                        if (Strategy::resolve($current) !== Strategy::resolve($candidate)) {
+                            throw new AuthorizationException('Changing device ownership or group would change its effective strategy and requires strategy write permission.');
+                        }
+                    });
+                }
+
+                static::query()->whereKey($ids)->update($attributes);
+                static::query()->whereKey($ids)->orderBy('id')->each(
+                    fn (Device $changed) => Strategy::syncResolvedFor($changed),
+                );
+                $changedCount += count($ids);
+                $lastId = max($ids);
+            } while (count($ids) === 500);
+
+            return $changedCount;
+        });
+    }
+
+    /** Remove a device while serializing active-fleet membership with confirms. */
+    public static function deleteWithStrategyContext(Device $device, bool $force = false): void
+    {
+        DB::transaction(function () use ($device, $force): void {
+            Strategy::query()->orderBy('id')->lockForUpdate()->get(['id']);
+            $locked = static::withTrashed()->whereKey($device->getKey())->lockForUpdate()->firstOrFail();
+            $force ? $locked->forceDelete() : $locked->delete();
+        });
+    }
+
+    /** Restore a device while serializing active-fleet membership with confirms. */
+    public static function restoreWithStrategyContext(Device $device): Device
+    {
+        return DB::transaction(function () use ($device): Device {
+            Strategy::query()->orderBy('id')->lockForUpdate()->get(['id']);
+            $locked = static::withTrashed()->whereKey($device->getKey())->lockForUpdate()->firstOrFail();
+            $locked->restore();
+
+            return $locked;
         });
     }
 

--- a/app/Models/Device.php
+++ b/app/Models/Device.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\ValidationException;
 
 class Device extends Model
 {
@@ -68,6 +69,7 @@ class Device extends Model
             'strategy_options' => 'array',
             'strategy_acked_options' => 'array',
             'strategy_acked_at' => 'datetime',
+            'strategy_rollout_ack_pending' => 'boolean',
         ];
     }
 
@@ -116,6 +118,18 @@ class Device extends Model
             $beforeResolution = $touchesContext ? Strategy::resolve($locked) : null;
             $locked->fill($attributes);
 
+            $activeMembershipChanges = ! $device->exists
+                ? ($locked->status ?? self::STATUS_ACTIVE) === self::STATUS_ACTIVE
+                : $locked->isDirty('status')
+                    && in_array(self::STATUS_ACTIVE, [$locked->getOriginal('status'), $locked->status], true);
+            if ($activeMembershipChanges) {
+                self::rejectOpenRolloutFleetChange('Wait for open strategy rollouts to finish before changing active fleet membership.');
+            }
+
+            if ($device->exists && $locked->isDirty(['user_id', 'device_group_id'])) {
+                self::rejectOpenRolloutFleetChange('Cancel open strategy rollouts before changing device owners or groups.');
+            }
+
             if ($touchesContext
                 && $locked->isDirty(['user_id', 'device_group_id'])
                 && ! $mayChangeResolvedStrategy
@@ -163,6 +177,11 @@ class Device extends Model
                 }
             });
 
+            if (! (clone $changedScope)->exists()) {
+                return 0;
+            }
+            self::rejectOpenRolloutFleetChange('Cancel open strategy rollouts before changing device owners or groups.');
+
             $changedCount = 0;
             $lastId = 0;
             do {
@@ -206,6 +225,9 @@ class Device extends Model
         DB::transaction(function () use ($device, $force): void {
             Strategy::query()->orderBy('id')->lockForUpdate()->get(['id']);
             $locked = static::withTrashed()->whereKey($device->getKey())->lockForUpdate()->firstOrFail();
+            if (! $locked->trashed() && $locked->status === self::STATUS_ACTIVE) {
+                self::rejectOpenRolloutFleetChange('Wait for open strategy rollouts to finish before removing active devices.');
+            }
             $force ? $locked->forceDelete() : $locked->delete();
         });
     }
@@ -216,10 +238,27 @@ class Device extends Model
         return DB::transaction(function () use ($device): Device {
             Strategy::query()->orderBy('id')->lockForUpdate()->get(['id']);
             $locked = static::withTrashed()->whereKey($device->getKey())->lockForUpdate()->firstOrFail();
+            if ($locked->trashed() && $locked->status === self::STATUS_ACTIVE) {
+                self::rejectOpenRolloutFleetChange('Wait for open strategy rollouts to finish before restoring active devices.');
+            }
             $locked->restore();
 
             return $locked;
         });
+    }
+
+    /** Frozen rollout targets cannot silently change fleet membership or precedence. */
+    private static function rejectOpenRolloutFleetChange(string $message): void
+    {
+        if (StrategyRollout::query()->whereIn('status', [
+            StrategyRollout::STATUS_SCHEDULED,
+            StrategyRollout::STATUS_ACTIVE,
+            StrategyRollout::STATUS_PAUSED,
+        ])->exists()) {
+            throw ValidationException::withMessages([
+                'rollout' => $message,
+            ]);
+        }
     }
 
     public function user(): BelongsTo

--- a/app/Models/Strategy.php
+++ b/app/Models/Strategy.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\ValidationException;
 
 /**
  * A named client-option policy (PLAN C2/C3).
@@ -30,7 +31,7 @@ use Illuminate\Support\Facades\DB;
  * A strategy cannot LOCK a setting in the client UI — only push it. The user
  * can change it back and nothing re-pushes until we send the policy again.
  */
-#[Fillable(['name', 'note', 'enabled', 'is_default', 'enforce', 'options'])]
+#[Fillable(['name', 'note', 'enabled', 'is_default', 'enforce', 'options', 'confirmation_timeout_minutes'])]
 class Strategy extends Model
 {
     use SoftDeletes;
@@ -148,6 +149,7 @@ class Strategy extends Model
             'is_default' => 'boolean',
             'enforce' => 'boolean',
             'options' => 'array',
+            'confirmation_timeout_minutes' => 'integer',
         ];
     }
 
@@ -280,7 +282,7 @@ class Strategy extends Model
         $this->options = self::sanitizeOptions($options);
     }
 
-    /** @return array{name:string,note:?string,enabled:bool,is_default:bool,enforce:bool,options:array<string,string>} */
+    /** @return array{name:string,note:?string,enabled:bool,is_default:bool,enforce:bool,confirmation_timeout_minutes:int,options:array<string,string>} */
     public function snapshot(): array
     {
         return [
@@ -289,6 +291,7 @@ class Strategy extends Model
             'enabled' => (bool) $this->enabled,
             'is_default' => (bool) $this->is_default,
             'enforce' => (bool) $this->enforce,
+            'confirmation_timeout_minutes' => (int) ($this->confirmation_timeout_minutes ?: 15),
             'options' => $this->optionMap(),
         ];
     }
@@ -301,6 +304,34 @@ class Strategy extends Model
     public function activeRevision(): BelongsTo
     {
         return $this->belongsTo(StrategyRevision::class, 'active_revision_id');
+    }
+
+    public function rollouts(): HasMany
+    {
+        return $this->hasMany(StrategyRollout::class)->orderByDesc('id');
+    }
+
+    /** @return array{options:array<string,string>,enforce:bool,rollout_target_id:?int,rollout_delivered_version:?int} */
+    public function desiredPolicyFor(Device $device): array
+    {
+        $rollout = StrategyRollout::releasedPolicyFor($this->id, $device->id);
+        if ($rollout === null) {
+            return ['options' => $this->configOptions(), 'enforce' => (bool) $this->enforce, 'rollout_target_id' => null, 'rollout_delivered_version' => null];
+        }
+        $snapshot = $rollout['snapshot'];
+
+        return [
+            'options' => ($snapshot['enabled'] ?? true) ? self::sanitizeOptions(is_array($snapshot['options'] ?? null) ? $snapshot['options'] : []) : [],
+            'enforce' => (bool) ($snapshot['enforce'] ?? false),
+            'rollout_target_id' => $rollout['target_id'],
+            'rollout_delivered_version' => $rollout['delivered_version'],
+        ];
+    }
+
+    /** @return array<string,string> */
+    public function desiredOptionsFor(Device $device): array
+    {
+        return $this->desiredPolicyFor($device)['options'];
     }
 
     /** @return array<string,array<string,array{group:string,type:string,values?:array<int,string>,min?:int,max?:int}>> */
@@ -354,6 +385,12 @@ class Strategy extends Model
                 self::LEVEL_DEVICE_GROUP => DeviceGroup::query()->whereKey($targetId)->lockForUpdate()->firstOrFail(),
             };
 
+            $current = DB::table($table)->where($column, $targetId)->value('strategy_id');
+            if (($current === null ? null : (int) $current) === $strategyId) {
+                return;
+            }
+            self::guardAssignmentChanges([$current, $strategyId]);
+
             DB::table($table)->where($column, $targetId)->delete();
             if ($strategyId !== null) {
                 DB::table($table)->insert([$column => $targetId, 'strategy_id' => $strategyId]);
@@ -361,6 +398,41 @@ class Strategy extends Model
 
             self::recomputeForLevel($level, $targetId);
         });
+    }
+
+    /** @param array<int,int|string|null> $strategyIds */
+    public static function guardNoOpenRollouts(array $strategyIds): void
+    {
+        $ids = collect($strategyIds)->filter()->map(fn ($id) => (int) $id)->unique()->sort()->values()->all();
+        if ($ids === []) {
+            return;
+        }
+        static::query()->whereIn('id', $ids)->orderBy('id')->lockForUpdate()->get(['id']);
+        if (StrategyRollout::query()->whereIn('strategy_id', $ids)
+            ->whereIn('status', StrategyRollout::OPEN_STATUSES)->exists()) {
+            throw ValidationException::withMessages(['strategy' => 'Pause or cancel the open rollout before changing assignments or policy.']);
+        }
+    }
+
+    public static function guardNoOpenPolicyChanges(): void
+    {
+        // Any strategy mutation can change effective precedence for a frozen
+        // target, even when a different strategy owns the open rollout.
+        if (StrategyRollout::query()->whereIn('status', StrategyRollout::OPEN_STATUSES)->exists()) {
+            throw ValidationException::withMessages(['strategy' => 'Wait for open strategy rollouts to finish before changing policy.']);
+        }
+    }
+
+    /** @param array<int,int|string|null> $strategyIds */
+    public static function guardAssignmentChanges(array $strategyIds): void
+    {
+        // A user/group/device pivot can change another strategy's effective
+        // fleet through precedence or fallback. Freeze every assignment writer
+        // while any rollout is open rather than attempting an incomplete local
+        // strategy-id check.
+        if (StrategyRollout::query()->whereIn('status', StrategyRollout::OPEN_STATUSES)->exists()) {
+            throw ValidationException::withMessages(['assignment' => 'Wait for open strategy rollouts to finish before changing assignments.']);
+        }
     }
 
     /** The strategy id assigned at one level, ignoring precedence. */
@@ -609,16 +681,27 @@ class Strategy extends Model
             return null;
         }
 
+        if ($device->strategy_rollout_ack_pending) {
+            StrategyRollout::confirmDeliveredToken($device->id, $echoedVersion);
+        }
+
         $strategy = $device->strategy_id_resolved !== null
             ? static::query()->find($device->strategy_id_resolved)
             : null;
+        $policy = $strategy?->desiredPolicyFor($device) ?? [
+            'options' => [], 'enforce' => false, 'rollout_target_id' => null, 'rollout_delivered_version' => null,
+        ];
 
-        $desired = $strategy?->configOptions() ?? [];
+        $desired = $policy['options'];
         $acked = self::stringMap($device->strategy_acked_options);
         $version = $device->strategy_version === null ? null : (int) $device->strategy_version;
 
         // Never had a policy and still does not: say nothing at all.
         if ($desired === [] && $acked === [] && $version === null) {
+            if ($policy['rollout_target_id'] !== null) {
+                StrategyRollout::markNoopTargetConfirmed($policy['rollout_target_id']);
+            }
+
             return null;
         }
 
@@ -669,10 +752,17 @@ class Strategy extends Model
             ])->saveQuietly();
         }
 
+        if ($policy['rollout_target_id'] !== null && $policy['rollout_delivered_version'] !== $version) {
+            StrategyRollout::markDeliveredTarget($policy['rollout_target_id'], $device->id, $version);
+            if ($echoedVersion === $version) {
+                StrategyRollout::confirmDeliveredToken($device->id, $echoedVersion);
+            }
+        }
+
         // The device echoed our current token: it is holding $desired (no bump
         // can have happened above, or the tokens would differ).
         if ($echoedVersion === $version) {
-            if (! ($strategy?->enforce)) {
+            if (! $policy['enforce']) {
                 return null; // up to date; let local edits stand
             }
 

--- a/app/Models/Strategy.php
+++ b/app/Models/Strategy.php
@@ -345,15 +345,22 @@ class Strategy extends Model
      */
     public static function assignTo(string $level, int $targetId, ?int $strategyId): void
     {
-        [$table, $column] = self::pivot($level);
+        DB::transaction(function () use ($level, $targetId, $strategyId): void {
+            [$table, $column] = self::pivot($level);
+            static::query()->orderBy('id')->lockForUpdate()->get(['id']);
+            match ($level) {
+                self::LEVEL_DEVICE => Device::withTrashed()->whereKey($targetId)->lockForUpdate()->firstOrFail(),
+                self::LEVEL_USER => User::query()->whereKey($targetId)->lockForUpdate()->firstOrFail(),
+                self::LEVEL_DEVICE_GROUP => DeviceGroup::query()->whereKey($targetId)->lockForUpdate()->firstOrFail(),
+            };
 
-        DB::table($table)->where($column, $targetId)->delete();
+            DB::table($table)->where($column, $targetId)->delete();
+            if ($strategyId !== null) {
+                DB::table($table)->insert([$column => $targetId, 'strategy_id' => $strategyId]);
+            }
 
-        if ($strategyId !== null) {
-            DB::table($table)->insert([$column => $targetId, 'strategy_id' => $strategyId]);
-        }
-
-        self::recomputeForLevel($level, $targetId);
+            self::recomputeForLevel($level, $targetId);
+        });
     }
 
     /** The strategy id assigned at one level, ignoring precedence. */

--- a/app/Models/Strategy.php
+++ b/app/Models/Strategy.php
@@ -4,7 +4,10 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Facades\DB;
 
 /**
@@ -30,6 +33,8 @@ use Illuminate\Support\Facades\DB;
 #[Fillable(['name', 'note', 'enabled', 'is_default', 'enforce', 'options'])]
 class Strategy extends Model
 {
+    use SoftDeletes;
+
     /** @var array<string,string> Assignment levels, highest precedence first. */
     public const LEVEL_DEVICE = 'device';
 
@@ -171,8 +176,21 @@ class Strategy extends Model
 
         static::deleted(function (Strategy $strategy) {
             self::$anyEnabledCache = null;
-            // Pivot rows cascade at the DB level; the cached column does not.
             static::recomputeAll();
+        });
+
+        static::deleting(function (Strategy $strategy) {
+            // Revision history holds a restricted foreign key to the strategy,
+            // so delete live routing state while retaining the historical owner.
+            foreach (self::PIVOTS as [$table]) {
+                DB::table($table)->where('strategy_id', $strategy->id)->delete();
+            }
+        });
+
+        static::restoring(function (Strategy $strategy) {
+            if ($strategy->is_default && static::query()->where('is_default', true)->exists()) {
+                $strategy->is_default = false;
+            }
         });
     }
 
@@ -260,6 +278,29 @@ class Strategy extends Model
     public function setOptions(array $options): void
     {
         $this->options = self::sanitizeOptions($options);
+    }
+
+    /** @return array{name:string,note:?string,enabled:bool,is_default:bool,enforce:bool,options:array<string,string>} */
+    public function snapshot(): array
+    {
+        return [
+            'name' => $this->name,
+            'note' => $this->note,
+            'enabled' => (bool) $this->enabled,
+            'is_default' => (bool) $this->is_default,
+            'enforce' => (bool) $this->enforce,
+            'options' => $this->optionMap(),
+        ];
+    }
+
+    public function revisions(): HasMany
+    {
+        return $this->hasMany(StrategyRevision::class)->orderByDesc('revision');
+    }
+
+    public function activeRevision(): BelongsTo
+    {
+        return $this->belongsTo(StrategyRevision::class, 'active_revision_id');
     }
 
     /** @return array<string,array<string,array{group:string,type:string,values?:array<int,string>,min?:int,max?:int}>> */

--- a/app/Models/StrategyRevision.php
+++ b/app/Models/StrategyRevision.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Facades\DB;
+
+#[Fillable(['strategy_id', 'revision', 'snapshot', 'change_note', 'created_by', 'created_by_name', 'affected_devices'])]
+class StrategyRevision extends Model
+{
+    protected static function booted(): void
+    {
+        static::updating(function (): never {
+            throw new \LogicException('Strategy revisions are immutable.');
+        });
+
+        static::deleting(function (): never {
+            throw new \LogicException('Strategy revisions are immutable.');
+        });
+    }
+
+    protected function casts(): array
+    {
+        return [
+            'snapshot' => 'array',
+            'revision' => 'integer',
+            'affected_devices' => 'integer',
+        ];
+    }
+
+    public function strategy(): BelongsTo
+    {
+        return $this->belongsTo(Strategy::class)->withTrashed();
+    }
+
+    public function creator(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'created_by');
+    }
+
+    /**
+     * @param  array<string,mixed>  $before
+     * @param  array<string,mixed>  $after
+     * @return array<int,array{key:string,before:mixed,after:mixed}>
+     */
+    public static function diffSnapshots(array $before, array $after): array
+    {
+        $changes = [];
+
+        foreach (['name', 'note', 'enabled', 'is_default', 'enforce'] as $key) {
+            if (($before[$key] ?? null) !== ($after[$key] ?? null)) {
+                $changes[] = ['key' => $key, 'before' => $before[$key] ?? null, 'after' => $after[$key] ?? null];
+            }
+        }
+
+        $beforeOptions = is_array($before['options'] ?? null) ? $before['options'] : [];
+        $afterOptions = is_array($after['options'] ?? null) ? $after['options'] : [];
+        foreach (array_unique([...array_keys($beforeOptions), ...array_keys($afterOptions)]) as $key) {
+            if (($beforeOptions[$key] ?? null) !== ($afterOptions[$key] ?? null)) {
+                $changes[] = [
+                    'key' => 'options.'.$key,
+                    'before' => $beforeOptions[$key] ?? null,
+                    'after' => $afterOptions[$key] ?? null,
+                ];
+            }
+        }
+
+        return $changes;
+    }
+
+    public static function capture(Strategy $strategy, ?int $userId, ?string $changeNote = null): self
+    {
+        return static::captureSnapshot($strategy, $strategy->snapshot(), $userId, $changeNote);
+    }
+
+    /** @param array<string,mixed> $snapshot */
+    public static function captureSnapshot(
+        Strategy $strategy,
+        array $snapshot,
+        ?int $userId,
+        ?string $changeNote = null,
+        ?int $affectedDevices = null,
+    ): self {
+        return DB::transaction(function () use ($strategy, $snapshot, $userId, $changeNote, $affectedDevices): self {
+            if ($changeNote !== null && mb_strlen($changeNote) > 500) {
+                throw new \InvalidArgumentException('Strategy revision notes may not exceed 500 characters.');
+            }
+
+            // Locking the owning strategy serializes allocation even when this is
+            // the first revision and MAX(revision) has no row to lock.
+            Strategy::query()->whereKey($strategy->id)->lockForUpdate()->firstOrFail();
+
+            $snapshot = [
+                'name' => (string) ($snapshot['name'] ?? $strategy->name),
+                'note' => isset($snapshot['note']) ? (string) $snapshot['note'] : null,
+                'enabled' => (bool) ($snapshot['enabled'] ?? $strategy->enabled),
+                'is_default' => (bool) ($snapshot['is_default'] ?? $strategy->is_default),
+                'enforce' => (bool) ($snapshot['enforce'] ?? $strategy->enforce),
+                'options' => Strategy::sanitizeOptions(is_array($snapshot['options'] ?? null) ? $snapshot['options'] : []),
+            ];
+
+            return static::query()->create([
+                'strategy_id' => $strategy->id,
+                'revision' => (int) static::query()->where('strategy_id', $strategy->id)->max('revision') + 1,
+                'snapshot' => $snapshot,
+                'change_note' => $changeNote,
+                'created_by' => $userId,
+                'created_by_name' => $userId === null ? null : User::query()->whereKey($userId)->value('username'),
+                'affected_devices' => $affectedDevices ?? $strategy->resolvedDevices()->count(),
+            ]);
+        });
+    }
+}

--- a/app/Models/StrategyRevision.php
+++ b/app/Models/StrategyRevision.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Facades\DB;
 
 #[Fillable(['strategy_id', 'revision', 'snapshot', 'change_note', 'created_by', 'created_by_name', 'affected_devices'])]
@@ -35,6 +36,11 @@ class StrategyRevision extends Model
         return $this->belongsTo(Strategy::class)->withTrashed();
     }
 
+    public function rollouts(): HasMany
+    {
+        return $this->hasMany(StrategyRollout::class, 'strategy_revision_id');
+    }
+
     public function creator(): BelongsTo
     {
         return $this->belongsTo(User::class, 'created_by');
@@ -49,7 +55,7 @@ class StrategyRevision extends Model
     {
         $changes = [];
 
-        foreach (['name', 'note', 'enabled', 'is_default', 'enforce'] as $key) {
+        foreach (['name', 'note', 'enabled', 'is_default', 'enforce', 'confirmation_timeout_minutes'] as $key) {
             if (($before[$key] ?? null) !== ($after[$key] ?? null)) {
                 $changes[] = ['key' => $key, 'before' => $before[$key] ?? null, 'after' => $after[$key] ?? null];
             }
@@ -98,6 +104,7 @@ class StrategyRevision extends Model
                 'enabled' => (bool) ($snapshot['enabled'] ?? $strategy->enabled),
                 'is_default' => (bool) ($snapshot['is_default'] ?? $strategy->is_default),
                 'enforce' => (bool) ($snapshot['enforce'] ?? $strategy->enforce),
+                'confirmation_timeout_minutes' => max(1, min(10080, (int) ($snapshot['confirmation_timeout_minutes'] ?? $strategy->confirmation_timeout_minutes ?? 15))),
                 'options' => Strategy::sanitizeOptions(is_array($snapshot['options'] ?? null) ? $snapshot['options'] : []),
             ];
 

--- a/app/Models/StrategyRollout.php
+++ b/app/Models/StrategyRollout.php
@@ -1,0 +1,421 @@
+<?php
+
+namespace App\Models;
+
+use Carbon\CarbonInterface;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\ValidationException;
+
+#[Fillable([
+    'strategy_id', 'strategy_revision_id', 'status', 'starts_at', 'batch_size',
+    'interval_minutes', 'next_release_at', 'created_by', 'paused_by',
+    'paused_at', 'completed_at',
+])]
+class StrategyRollout extends Model
+{
+    public const STATUS_SCHEDULED = 'scheduled';
+
+    public const STATUS_ACTIVE = 'active';
+
+    public const STATUS_PAUSED = 'paused';
+
+    public const STATUS_COMPLETED = 'completed';
+
+    public const STATUS_CANCELLED = 'cancelled';
+
+    public const OPEN_STATUSES = [self::STATUS_SCHEDULED, self::STATUS_ACTIVE, self::STATUS_PAUSED];
+
+    protected static function booted(): void
+    {
+        static::deleting(function (): never {
+            throw new \LogicException('Strategy rollout evidence is immutable and cannot be deleted directly.');
+        });
+    }
+
+    protected function casts(): array
+    {
+        return [
+            'starts_at' => 'datetime',
+            'next_release_at' => 'datetime',
+            'paused_at' => 'datetime',
+            'completed_at' => 'datetime',
+            'batch_size' => 'integer',
+            'interval_minutes' => 'integer',
+        ];
+    }
+
+    public function strategy(): BelongsTo
+    {
+        return $this->belongsTo(Strategy::class)->withTrashed();
+    }
+
+    public function revision(): BelongsTo
+    {
+        return $this->belongsTo(StrategyRevision::class, 'strategy_revision_id');
+    }
+
+    public function targets(): HasMany
+    {
+        return $this->hasMany(StrategyRolloutDevice::class);
+    }
+
+    public function getTargetCountAttribute(): int
+    {
+        return isset($this->attributes['targets_count'])
+            ? (int) $this->attributes['targets_count']
+            : $this->targets()->count();
+    }
+
+    /**
+     * @param  iterable<int,int|string>  $deviceIds  Arrays are normalized here;
+     *                                               streams must already be unique and ordered.
+     */
+    public static function schedule(
+        Strategy $strategy,
+        StrategyRevision $revision,
+        iterable $deviceIds,
+        CarbonInterface $startsAt,
+        int $batchSize,
+        int $intervalMinutes,
+        ?int $userId,
+    ): self {
+        $batchSize = max(1, min(1000, $batchSize));
+        $intervalMinutes = max(1, min(10080, $intervalMinutes));
+        if (is_array($deviceIds)) {
+            $deviceIds = collect($deviceIds)->map(fn ($id) => (int) $id)->filter()->unique()->sort()->values()->all();
+        }
+
+        $rollout = DB::transaction(function () use (
+            $strategy, $revision, $deviceIds, $startsAt, $batchSize, $intervalMinutes, $userId,
+        ): self {
+            Strategy::query()->orderBy('id')->lockForUpdate()->get(['id']);
+            $strategy = Strategy::findOrFail($strategy->id);
+            if ($revision->strategy_id !== $strategy->id) {
+                throw ValidationException::withMessages(['rollout' => 'The selected revision does not belong to this strategy.']);
+            }
+            if (static::query()->where('strategy_id', $strategy->id)
+                ->whereIn('status', [self::STATUS_SCHEDULED, self::STATUS_ACTIVE, self::STATUS_PAUSED])
+                ->lockForUpdate()->exists()) {
+                throw ValidationException::withMessages(['rollout' => 'This strategy already has a scheduled or active rollout.']);
+            }
+
+            $snapshot = is_array($revision->snapshot) ? $revision->snapshot : [];
+            if (($snapshot['name'] ?? $strategy->name) !== $strategy->name
+                || (bool) ($snapshot['enabled'] ?? $strategy->enabled) !== (bool) $strategy->enabled
+                || (bool) ($snapshot['is_default'] ?? $strategy->is_default) !== (bool) $strategy->is_default
+                || (int) ($snapshot['confirmation_timeout_minutes'] ?? $strategy->confirmation_timeout_minutes) !== (int) $strategy->confirmation_timeout_minutes) {
+                throw ValidationException::withMessages([
+                    'rollout' => 'Staged rollouts cannot change strategy identity, enabled state, default resolution, or confirmation timeout.',
+                ]);
+            }
+
+            $scheduled = $startsAt->isFuture();
+            $rollout = static::query()->create([
+                'strategy_id' => $strategy->id,
+                'strategy_revision_id' => $revision->id,
+                'status' => $scheduled ? self::STATUS_SCHEDULED : self::STATUS_ACTIVE,
+                'starts_at' => $startsAt,
+                'batch_size' => $batchSize,
+                'interval_minutes' => $intervalMinutes,
+                'next_release_at' => $scheduled ? $startsAt : now(),
+                'created_by' => $userId,
+            ]);
+
+            $position = 1;
+            $buffer = [];
+            foreach ($deviceIds as $deviceId) {
+                $deviceId = (int) $deviceId;
+                if ($deviceId <= 0) {
+                    continue;
+                }
+                $buffer[] = $deviceId;
+                if (count($buffer) === 100) {
+                    self::insertTargets($rollout->id, $buffer, $position);
+                    $buffer = [];
+                }
+            }
+            if ($buffer !== []) {
+                self::insertTargets($rollout->id, $buffer, $position);
+            }
+            if ($position === 1) {
+                throw ValidationException::withMessages(['rollout' => 'A staged rollout requires at least one target device.']);
+            }
+
+            return $rollout;
+        });
+
+        if ($rollout->status === self::STATUS_ACTIVE) {
+            $rollout->releaseNextBatch();
+        }
+
+        return $rollout->fresh();
+    }
+
+    /** @param array<int,int> $deviceIds */
+    private static function insertTargets(int $rolloutId, array $deviceIds, int &$position): void
+    {
+        $names = Device::withTrashed()->whereIn('id', $deviceIds)->pluck('rustdesk_id', 'id');
+        $now = now();
+        $rows = [];
+        foreach ($deviceIds as $deviceId) {
+            if (! $names->has($deviceId)) {
+                continue;
+            }
+            $rows[] = [
+                'strategy_rollout_id' => $rolloutId,
+                'device_id' => $deviceId,
+                'device_rustdesk_id' => $names->get($deviceId),
+                'position' => $position++,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ];
+        }
+        if ($rows !== []) {
+            DB::table('strategy_rollout_devices')->insert($rows);
+        }
+    }
+
+    public function releaseNextBatch(): bool
+    {
+        $advanced = DB::transaction(function (): bool {
+            // Shared lock order: all strategies, then rollout, then targets.
+            Strategy::query()->orderBy('id')->lockForUpdate()->get(['id']);
+            $rollout = static::query()->lockForUpdate()->findOrFail($this->id);
+            if ($rollout->status !== self::STATUS_ACTIVE || $rollout->next_release_at === null || $rollout->next_release_at->isFuture()) {
+                return false;
+            }
+
+            if (! $this->closeOrWaitForReleasedCohort($rollout)) {
+                return false;
+            }
+
+            $ids = DB::table('strategy_rollout_devices')->where('strategy_rollout_id', $rollout->id)
+                ->whereNull('released_at')->orderBy('position')->limit($rollout->batch_size)->lockForUpdate()->pluck('id');
+            if ($ids->isNotEmpty()) {
+                DB::table('strategy_rollout_devices')->whereIn('id', $ids)->update(['released_at' => now(), 'updated_at' => now()]);
+                // Even the final batch must be confirmed or time out before the
+                // candidate becomes the global active revision.
+                $rollout->update(['next_release_at' => now()->addMinutes($rollout->interval_minutes)]);
+
+                return true;
+            }
+
+            // No unreleased targets remain and every released target is terminal.
+            $rollout->complete();
+
+            return true;
+        });
+        $this->refresh();
+
+        return $advanced;
+    }
+
+    /** Mark expired confirmations and defer while any released target is pending. */
+    private function closeOrWaitForReleasedCohort(StrategyRollout $rollout): bool
+    {
+        $targets = StrategyRolloutDevice::query()->where('strategy_rollout_id', $rollout->id)
+            ->whereNotNull('released_at')
+            ->whereNull('confirmed_at')
+            ->whereNull('timed_out_at')
+            ->orderBy('position')
+            ->lockForUpdate()
+            ->get(['id', 'released_at']);
+        if ($targets->isEmpty()) {
+            return true;
+        }
+
+        $timeout = max(1, (int) $rollout->strategy()->value('confirmation_timeout_minutes'));
+        $cutoff = now()->subMinutes($timeout);
+        $expired = $targets->filter(fn (StrategyRolloutDevice $target) => $target->released_at->lte($cutoff));
+        if ($expired->isNotEmpty()) {
+            StrategyRolloutDevice::query()->whereIn('id', $expired->pluck('id'))->update([
+                'timed_out_at' => now(),
+                'updated_at' => now(),
+            ]);
+        }
+
+        $waiting = $targets->reject(fn (StrategyRolloutDevice $target) => $expired->contains('id', $target->id));
+        if ($waiting->isEmpty()) {
+            return true;
+        }
+
+        $nextDeadline = $waiting->min(fn (StrategyRolloutDevice $target) => $target->released_at->copy()->addMinutes($timeout));
+        $rollout->update(['next_release_at' => $nextDeadline->isFuture() ? $nextDeadline : now()->addMinute()]);
+
+        return false;
+    }
+
+    public function pause(?int $userId): bool
+    {
+        $paused = DB::transaction(function () use ($userId): bool {
+            Strategy::query()->orderBy('id')->lockForUpdate()->get(['id']);
+            $rollout = static::query()->lockForUpdate()->findOrFail($this->id);
+            if ($rollout->status !== self::STATUS_ACTIVE) {
+                return false;
+            }
+            $rollout->update([
+                'status' => self::STATUS_PAUSED,
+                'paused_by' => $userId,
+                'paused_at' => now(),
+                'next_release_at' => null,
+            ]);
+
+            return true;
+        });
+        $this->refresh();
+
+        return $paused;
+    }
+
+    public function resume(): bool
+    {
+        $resumed = DB::transaction(function (): bool {
+            Strategy::query()->orderBy('id')->lockForUpdate()->get(['id']);
+            $rollout = static::query()->lockForUpdate()->findOrFail($this->id);
+            if ($rollout->status !== self::STATUS_PAUSED) {
+                return false;
+            }
+            $rollout->update([
+                'status' => self::STATUS_ACTIVE,
+                'paused_by' => null,
+                'paused_at' => null,
+                'next_release_at' => now(),
+            ]);
+
+            return true;
+        });
+        $this->refresh();
+
+        if ($resumed) {
+            $this->releaseNextBatch();
+        }
+
+        return $resumed;
+    }
+
+    public function cancel(): bool
+    {
+        $cancelled = DB::transaction(function (): bool {
+            Strategy::query()->orderBy('id')->lockForUpdate()->get(['id']);
+            $rollout = static::query()->lockForUpdate()->findOrFail($this->id);
+            if (! in_array($rollout->status, [self::STATUS_SCHEDULED, self::STATUS_ACTIVE, self::STATUS_PAUSED], true)) {
+                return false;
+            }
+            if ($rollout->targets()->whereNotNull('released_at')->exists()) {
+                throw ValidationException::withMessages([
+                    'rollout' => 'A rollout can only be cancelled before its first batch is released.',
+                ]);
+            }
+            $rollout->update([
+                'status' => self::STATUS_CANCELLED,
+                'next_release_at' => null,
+                'completed_at' => now(),
+            ]);
+
+            return true;
+        });
+        $this->refresh();
+
+        return $cancelled;
+    }
+
+    /** Advance every rollout whose start/release boundary is due. */
+    public static function advanceDue(): int
+    {
+        $advanced = 0;
+        static::query()->where('status', self::STATUS_SCHEDULED)->where('starts_at', '<=', now())->orderBy('id')->pluck('id')
+            ->each(function (int $id) use (&$advanced): void {
+                $started = static::query()->whereKey($id)->where('status', self::STATUS_SCHEDULED)->update([
+                    'status' => self::STATUS_ACTIVE, 'next_release_at' => now(), 'updated_at' => now(),
+                ]);
+                if ($started === 1 && static::findOrFail($id)->releaseNextBatch()) {
+                    $advanced++;
+                }
+            });
+        static::query()->where('status', self::STATUS_ACTIVE)->where('next_release_at', '<=', now())->orderBy('id')->pluck('id')
+            ->each(function (int $id) use (&$advanced): void {
+                if (static::findOrFail($id)->releaseNextBatch()) {
+                    $advanced++;
+                }
+            });
+
+        return $advanced;
+    }
+
+    private function complete(): void
+    {
+        $revision = $this->revision()->lockForUpdate()->firstOrFail();
+        $strategy = $this->strategy()->lockForUpdate()->firstOrFail();
+        $snapshot = $revision->snapshot;
+        $strategy->fill([
+            'note' => $snapshot['note'] ?? null,
+            'enabled' => (bool) ($snapshot['enabled'] ?? true),
+            'is_default' => (bool) ($snapshot['is_default'] ?? false),
+            'enforce' => (bool) ($snapshot['enforce'] ?? false),
+            'confirmation_timeout_minutes' => (int) ($snapshot['confirmation_timeout_minutes'] ?? 15),
+        ]);
+        $strategy->setOptions(is_array($snapshot['options'] ?? null) ? $snapshot['options'] : []);
+        $strategy->save();
+        $strategy->forceFill(['active_revision_id' => $revision->id])->saveQuietly();
+        $this->update(['status' => self::STATUS_COMPLETED, 'next_release_at' => null, 'completed_at' => now()]);
+    }
+
+    /** @return array{snapshot:array<string,mixed>,target_id:int,delivered_version:?int}|null */
+    public static function releasedPolicyFor(int $strategyId, int $deviceId): ?array
+    {
+        $row = DB::table('strategy_rollouts')
+            ->join('strategy_rollout_devices', 'strategy_rollout_devices.strategy_rollout_id', '=', 'strategy_rollouts.id')
+            ->join('strategy_revisions', 'strategy_revisions.id', '=', 'strategy_rollouts.strategy_revision_id')
+            ->join('strategies', 'strategies.id', '=', 'strategy_rollouts.strategy_id')
+            ->where('strategy_rollouts.strategy_id', $strategyId)
+            ->where(function ($query): void {
+                $query->whereIn('strategy_rollouts.status', [self::STATUS_ACTIVE, self::STATUS_PAUSED])
+                    ->orWhere(function ($query): void {
+                        $query->where('strategy_rollouts.status', self::STATUS_COMPLETED)
+                            ->whereColumn('strategies.active_revision_id', 'strategy_rollouts.strategy_revision_id')
+                            ->whereNull('strategy_rollout_devices.delivered_version');
+                    });
+            })
+            ->where('strategy_rollout_devices.device_id', $deviceId)
+            ->whereNotNull('strategy_rollout_devices.released_at')->orderByDesc('strategy_rollouts.id')
+            ->first(['strategy_rollout_devices.id as target_id', 'strategy_rollout_devices.delivered_version', 'strategy_revisions.snapshot']);
+        if ($row === null) {
+            return null;
+        }
+        $snapshot = is_string($row->snapshot) ? json_decode($row->snapshot, true, flags: JSON_THROW_ON_ERROR) : $row->snapshot;
+
+        return ['snapshot' => is_array($snapshot) ? $snapshot : [], 'target_id' => (int) $row->target_id, 'delivered_version' => $row->delivered_version === null ? null : (int) $row->delivered_version];
+    }
+
+    public static function markDeliveredTarget(int $targetId, int $deviceId, int $version): void
+    {
+        $updated = DB::table('strategy_rollout_devices')->where('id', $targetId)->where('device_id', $deviceId)
+            ->where(fn ($query) => $query->whereNull('delivered_version')->orWhere('delivered_version', '!=', $version))
+            ->update(['delivered_version' => $version, 'delivered_at' => now(), 'updated_at' => now()]);
+        if ($updated === 1) {
+            DB::table('devices')->where('id', $deviceId)->update(['strategy_rollout_ack_pending' => true]);
+        }
+    }
+
+    public static function markNoopTargetConfirmed(int $targetId): void
+    {
+        DB::table('strategy_rollout_devices')->where('id', $targetId)->whereNull('confirmed_at')
+            ->update(['delivered_at' => now(), 'confirmed_at' => now(), 'updated_at' => now()]);
+    }
+
+    public static function confirmDeliveredToken(int $deviceId, int $echoedVersion): void
+    {
+        if ($echoedVersion <= 0) {
+            return;
+        }
+        DB::table('strategy_rollout_devices')->where('device_id', $deviceId)->where('delivered_version', $echoedVersion)->whereNull('confirmed_at')
+            ->update(['confirmed_at' => now(), 'updated_at' => now()]);
+        if (! DB::table('strategy_rollout_devices')->where('device_id', $deviceId)->whereNotNull('delivered_version')->whereNull('confirmed_at')->exists()) {
+            DB::table('devices')->where('id', $deviceId)->update(['strategy_rollout_ack_pending' => false]);
+        }
+    }
+}

--- a/app/Models/StrategyRolloutDevice.php
+++ b/app/Models/StrategyRolloutDevice.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+#[Fillable(['strategy_rollout_id', 'device_id', 'device_rustdesk_id', 'position', 'released_at', 'delivered_version', 'delivered_at', 'confirmed_at', 'timed_out_at'])]
+class StrategyRolloutDevice extends Model
+{
+    protected static function booted(): void
+    {
+        static::deleting(function (): never {
+            throw new \LogicException('Strategy rollout target evidence is immutable and cannot be deleted directly.');
+        });
+    }
+
+    protected function casts(): array
+    {
+        return [
+            'position' => 'integer',
+            'released_at' => 'datetime',
+            'delivered_version' => 'integer',
+            'delivered_at' => 'datetime',
+            'confirmed_at' => 'datetime',
+            'timed_out_at' => 'datetime',
+        ];
+    }
+
+    public function rollout(): BelongsTo
+    {
+        return $this->belongsTo(StrategyRollout::class, 'strategy_rollout_id');
+    }
+
+    public function device(): BelongsTo
+    {
+        return $this->belongsTo(Device::class)->withTrashed();
+    }
+}

--- a/app/Services/StrategyAssignmentImpact.php
+++ b/app/Services/StrategyAssignmentImpact.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Device;
+use App\Models\Strategy;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+
+/** Builds an assignment preview and fingerprints its complete routing source. */
+class StrategyAssignmentImpact
+{
+    private const LEVELS = [
+        Strategy::LEVEL_DEVICE => ['device_strategy', 'device_id'],
+        Strategy::LEVEL_USER => ['strategy_user', 'user_id'],
+        Strategy::LEVEL_DEVICE_GROUP => ['device_group_strategy', 'device_group_id'],
+    ];
+
+    /**
+     * @param  array<int,int|string>  $deviceIds
+     * @param  array<int,int|string>  $userIds
+     * @param  array<int,int|string>  $groupIds
+     * @return array<string,mixed>
+     */
+    public static function preview(Strategy $strategy, array $deviceIds, array $userIds, array $groupIds): array
+    {
+        $desired = [
+            Strategy::LEVEL_DEVICE => self::ids($deviceIds),
+            Strategy::LEVEL_USER => self::ids($userIds),
+            Strategy::LEVEL_DEVICE_GROUP => self::ids($groupIds),
+        ];
+        $desiredLookup = array_map(fn (array $ids) => array_fill_keys($ids, true), $desired);
+        $hash = hash_init('sha256');
+        hash_update($hash, json_encode(['strategy_id' => $strategy->id, 'desired' => $desired], JSON_THROW_ON_ERROR));
+
+        $strategies = Strategy::query()->orderBy('id')->get(['id', 'name', 'enabled', 'is_default', 'enforce', 'options']);
+        $enabled = $strategies->mapWithKeys(fn (Strategy $item) => [(int) $item->id => (bool) $item->enabled])->all();
+        $names = $strategies->pluck('name', 'id')->all();
+        $defaultId = $strategies->first(fn (Strategy $item) => $item->enabled && $item->is_default)?->id;
+        foreach ($strategies as $item) {
+            hash_update($hash, 'strategy:'.$item->id.':'.$item->name.':'.(int) $item->enabled.':'.(int) $item->is_default.':'.(int) $item->enforce.':'.json_encode($item->optionMap(), JSON_THROW_ON_ERROR).';');
+        }
+
+        $assignmentChanges = [];
+        foreach (self::LEVELS as $level => [$table, $column]) {
+            $currentCount = DB::table($table)->where('strategy_id', $strategy->id)->count();
+            $retained = 0;
+            foreach (array_chunk($desired[$level], 500) as $chunk) {
+                $retained += DB::table($table)->where('strategy_id', $strategy->id)->whereIn($column, $chunk)->count();
+            }
+            $assignmentChanges[$level] = [
+                'added_count' => count($desired[$level]) - $retained,
+                'removed_count' => $currentCount - $retained,
+            ];
+            DB::table($table)->orderBy($column)->chunkById(500, function (Collection $rows) use ($hash, $level, $column): void {
+                foreach ($rows as $row) {
+                    hash_update($hash, $level.':'.$row->{$column}.':'.$row->strategy_id.';');
+                }
+            }, $column);
+        }
+
+        $affectedCount = 0;
+        $affectedDevices = [];
+        Device::query()->where('status', Device::STATUS_ACTIVE)->orderBy('id')->chunkById(500,
+            function (Collection $devices) use ($strategy, $desiredLookup, $enabled, $names, $defaultId, $hash, &$affectedCount, &$affectedDevices): void {
+                $deviceIds = $devices->pluck('id')->all();
+                $userIds = $devices->pluck('user_id')->filter()->unique()->all();
+                $groupIds = $devices->pluck('device_group_id')->filter()->unique()->all();
+                $maps = [
+                    Strategy::LEVEL_DEVICE => DB::table('device_strategy')->whereIn('device_id', $deviceIds)->pluck('strategy_id', 'device_id')->all(),
+                    Strategy::LEVEL_USER => $userIds === [] ? [] : DB::table('strategy_user')->whereIn('user_id', $userIds)->pluck('strategy_id', 'user_id')->all(),
+                    Strategy::LEVEL_DEVICE_GROUP => $groupIds === [] ? [] : DB::table('device_group_strategy')->whereIn('device_group_id', $groupIds)->pluck('strategy_id', 'device_group_id')->all(),
+                ];
+
+                foreach ($devices as $device) {
+                    hash_update($hash, 'device:'.$device->id.':'.$device->user_id.':'.$device->device_group_id.':'.$device->strategy_id_resolved.';');
+                    $targets = [
+                        Strategy::LEVEL_DEVICE => (int) $device->id,
+                        Strategy::LEVEL_USER => $device->user_id === null ? null : (int) $device->user_id,
+                        Strategy::LEVEL_DEVICE_GROUP => $device->device_group_id === null ? null : (int) $device->device_group_id,
+                    ];
+                    $candidates = [];
+                    foreach ($targets as $level => $targetId) {
+                        if ($targetId === null) {
+                            $candidates[$level] = null;
+
+                            continue;
+                        }
+                        $current = $maps[$level][$targetId] ?? null;
+                        if (isset($desiredLookup[$level][$targetId])) {
+                            $current = $strategy->id;
+                        } elseif ((int) $current === (int) $strategy->id) {
+                            $current = null;
+                        }
+                        $candidates[$level] = $current;
+                    }
+                    $candidates['default'] = $defaultId;
+
+                    $winner = null;
+                    $winningLevel = null;
+                    foreach ($candidates as $level => $candidate) {
+                        if ($candidate !== null && ($enabled[(int) $candidate] ?? false)) {
+                            $winner = (int) $candidate;
+                            $winningLevel = $level;
+                            break;
+                        }
+                    }
+
+                    $before = $device->strategy_id_resolved === null ? null : (int) $device->strategy_id_resolved;
+                    if ($before !== $winner) {
+                        $affectedCount++;
+                        if (count($affectedDevices) < 50) {
+                            $affectedDevices[] = [
+                                'id' => $device->id,
+                                'rustdesk_id' => $device->rustdesk_id,
+                                'label' => $device->alias ?: ($device->hostname ?: $device->rustdesk_id),
+                                'before_strategy' => $before ? ($names[$before] ?? 'Unknown') : 'None',
+                                'after_strategy' => $winner ? ($names[$winner] ?? 'Unknown') : 'None',
+                                'winning_level' => $winningLevel,
+                            ];
+                        }
+                    }
+                }
+            });
+
+        usort($affectedDevices, fn (array $a, array $b) => strcmp($a['rustdesk_id'], $b['rustdesk_id']));
+
+        return [
+            'affected_count' => $affectedCount,
+            'affected_devices' => $affectedDevices,
+            'assignment_changes' => $assignmentChanges,
+            'fingerprint' => hash_final($hash),
+        ];
+    }
+
+    /** @param array<int,int|string> $ids @return array<int,int> */
+    private static function ids(array $ids): array
+    {
+        return collect($ids)->map(fn ($id) => (int) $id)->filter()->unique()->sort()->values()->all();
+    }
+}

--- a/app/Services/StrategyImpact.php
+++ b/app/Services/StrategyImpact.php
@@ -1,0 +1,175 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Device;
+use App\Models\Strategy;
+use Illuminate\Support\Facades\DB;
+
+/** Builds a reviewed policy change and fingerprints every input to its result. */
+class StrategyImpact
+{
+    /** @param array<string,mixed> $proposed @return array<string,mixed> */
+    public static function preview(?Strategy $strategy, array $proposed, bool $includeSample = true): array
+    {
+        $before = self::snapshot($strategy);
+        $beforeOptions = $before['options'];
+        $afterOptions = Strategy::sanitizeOptions(is_array($proposed['options'] ?? null) ? $proposed['options'] : []);
+        $optionChanges = [];
+
+        foreach (array_unique([...array_keys($beforeOptions), ...array_keys($afterOptions)]) as $key) {
+            $old = $beforeOptions[$key] ?? null;
+            $new = $afterOptions[$key] ?? null;
+            if ($old !== $new) {
+                $optionChanges[$key] = ['before' => $old, 'after' => $new];
+            }
+        }
+        ksort($optionChanges);
+
+        $dangerousValues = [
+            'access-mode' => ['view'],
+            'enable-keyboard' => ['N'],
+            'enable-file-transfer' => ['N'],
+            'enable-terminal' => ['N'],
+            'allow-remote-config-modification' => ['Y'],
+        ];
+        $dangerous = [];
+        foreach ($optionChanges as $key => $change) {
+            if (isset($dangerousValues[$key]) && in_array($change['after'], $dangerousValues[$key], true)) {
+                $dangerous[] = ['key' => $key, 'before' => $change['before'], 'after' => $change['after']];
+            }
+        }
+
+        $snapshot = [
+            'name' => (string) ($proposed['name'] ?? ''),
+            'note' => $proposed['note'] ?? null,
+            'enabled' => (bool) ($proposed['enabled'] ?? false),
+            'is_default' => (bool) ($proposed['is_default'] ?? false),
+            'enforce' => (bool) ($proposed['enforce'] ?? false),
+            'options' => $afterOptions,
+            'operation' => (string) ($proposed['operation'] ?? 'save'),
+            'restore_revision_id' => isset($proposed['restore_revision_id']) ? (int) $proposed['restore_revision_id'] : null,
+        ];
+        $policyChanged = $optionChanges !== []
+            || $before['enabled'] !== $snapshot['enabled']
+            || $before['is_default'] !== $snapshot['is_default']
+            || $before['enforce'] !== $snapshot['enforce'];
+        $scan = self::scan($strategy, $snapshot, $policyChanged, $includeSample);
+
+        return [
+            'option_changes' => $optionChanges,
+            'dangerous' => $dangerous,
+            'resets' => collect($optionChanges)
+                ->filter(fn (array $change) => $change['before'] !== null && $change['after'] === null)
+                ->keys()->values()->all(),
+            'affected_count' => $scan['count'],
+            'affected_devices' => $scan['sample'],
+            'metadata_changes' => collect(['name', 'note', 'enabled', 'is_default', 'enforce'])
+                ->filter(fn (string $key) => $before[$key] !== $snapshot[$key])
+                ->mapWithKeys(fn (string $key) => [$key => [
+                    'before' => $before[$key],
+                    'after' => $snapshot[$key],
+                ]])->all(),
+            'fingerprint' => $scan['fingerprint'],
+        ];
+    }
+
+    /** @return array{name:?string,note:?string,enabled:bool,is_default:bool,enforce:bool,options:array<string,string>} */
+    private static function snapshot(?Strategy $strategy): array
+    {
+        return $strategy === null ? [
+            'name' => null,
+            'note' => null,
+            'enabled' => false,
+            'is_default' => false,
+            'enforce' => false,
+            'options' => [],
+        ] : [
+            'name' => $strategy->name,
+            'note' => $strategy->note,
+            'enabled' => (bool) $strategy->enabled,
+            'is_default' => (bool) $strategy->is_default,
+            'enforce' => (bool) $strategy->enforce,
+            'options' => $strategy->optionMap(),
+        ];
+    }
+
+    /** @param array<string,mixed> $proposed @return array{count:int,sample:array<int,array<string,mixed>>,fingerprint:string} */
+    private static function scan(?Strategy $strategy, array $proposed, bool $policyChanged, bool $includeSample = true): array
+    {
+        $hash = hash_init('sha256');
+        hash_update($hash, json_encode([
+            'strategy_id' => $strategy?->id,
+            'proposed' => $proposed,
+        ], JSON_THROW_ON_ERROR));
+
+        $targetId = $strategy?->id ?? -1;
+        $strategies = Strategy::query()->orderBy('id')->get(['id', 'name', 'enabled', 'is_default', 'enforce', 'options']);
+        $enabled = $strategies->mapWithKeys(fn (Strategy $item) => [(int) $item->id => (bool) $item->enabled])->all();
+        $enabled[$targetId] = (bool) $proposed['enabled'];
+        foreach ($strategies as $item) {
+            hash_update($hash, 'strategy:'.$item->id.':'.$item->name.':'.(int) $item->enabled.':'.(int) $item->is_default.':'.(int) $item->enforce.':'.json_encode($item->optionMap(), JSON_THROW_ON_ERROR).';');
+        }
+
+        $defaultId = ($proposed['enabled'] && $proposed['is_default'])
+            ? $targetId
+            : $strategies->first(fn (Strategy $item) => $item->id !== $strategy?->id && $item->enabled && $item->is_default)?->id;
+
+        foreach ([
+            Strategy::LEVEL_DEVICE => ['device_strategy', 'device_id'],
+            Strategy::LEVEL_USER => ['strategy_user', 'user_id'],
+            Strategy::LEVEL_DEVICE_GROUP => ['device_group_strategy', 'device_group_id'],
+        ] as $level => [$table, $column]) {
+            DB::table($table)->orderBy($column)->each(function ($row) use ($hash, $level, $column): void {
+                hash_update($hash, $level.':'.$row->{$column}.':'.$row->strategy_id.';');
+            });
+        }
+
+        $count = 0;
+        $sample = [];
+        Device::query()->where('status', Device::STATUS_ACTIVE)->orderBy('id')->chunkById(500,
+            function ($devices) use ($hash, $enabled, $defaultId, $targetId, $policyChanged, $includeSample, &$count, &$sample): void {
+                $deviceIds = $devices->pluck('id')->all();
+                $userIds = $devices->pluck('user_id')->filter()->unique()->all();
+                $groupIds = $devices->pluck('device_group_id')->filter()->unique()->all();
+                $direct = DB::table('device_strategy')->whereIn('device_id', $deviceIds)->pluck('strategy_id', 'device_id')->all();
+                $owners = $userIds === [] ? [] : DB::table('strategy_user')->whereIn('user_id', $userIds)->pluck('strategy_id', 'user_id')->all();
+                $groups = $groupIds === [] ? [] : DB::table('device_group_strategy')->whereIn('device_group_id', $groupIds)->pluck('strategy_id', 'device_group_id')->all();
+
+                foreach ($devices as $device) {
+                    hash_update($hash, 'device:'.$device->id.':'.$device->user_id.':'.$device->device_group_id.':'.$device->strategy_id_resolved.';');
+                    $winner = null;
+                    $winningLevel = null;
+                    foreach ([
+                        Strategy::LEVEL_DEVICE => $direct[$device->id] ?? null,
+                        Strategy::LEVEL_USER => $device->user_id === null ? null : ($owners[$device->user_id] ?? null),
+                        Strategy::LEVEL_DEVICE_GROUP => $device->device_group_id === null ? null : ($groups[$device->device_group_id] ?? null),
+                        'default' => $defaultId,
+                    ] as $level => $candidate) {
+                        if ($candidate !== null && ($enabled[(int) $candidate] ?? false)) {
+                            $winner = (int) $candidate;
+                            $winningLevel = $level;
+                            break;
+                        }
+                    }
+
+                    $current = $device->strategy_id_resolved === null ? null : (int) $device->strategy_id_resolved;
+                    if ($policyChanged && ($winner !== $current || $winner === $targetId)) {
+                        $count++;
+                        if ($includeSample && count($sample) < 50) {
+                            $sample[] = [
+                                'id' => $device->id,
+                                'rustdesk_id' => $device->rustdesk_id,
+                                'label' => $device->alias ?: ($device->hostname ?: $device->rustdesk_id),
+                                'winning_level' => $winningLevel,
+                            ];
+                        }
+                    }
+                }
+            });
+
+        usort($sample, fn (array $a, array $b) => strcmp($a['rustdesk_id'], $b['rustdesk_id']));
+
+        return ['count' => $count, 'sample' => $sample, 'fingerprint' => hash_final($hash)];
+    }
+}

--- a/app/Services/StrategyImpact.php
+++ b/app/Services/StrategyImpact.php
@@ -46,6 +46,7 @@ class StrategyImpact
             'enabled' => (bool) ($proposed['enabled'] ?? false),
             'is_default' => (bool) ($proposed['is_default'] ?? false),
             'enforce' => (bool) ($proposed['enforce'] ?? false),
+            'confirmation_timeout_minutes' => (int) ($proposed['confirmation_timeout_minutes'] ?? 15),
             'options' => $afterOptions,
             'operation' => (string) ($proposed['operation'] ?? 'save'),
             'restore_revision_id' => isset($proposed['restore_revision_id']) ? (int) $proposed['restore_revision_id'] : null,
@@ -64,7 +65,7 @@ class StrategyImpact
                 ->keys()->values()->all(),
             'affected_count' => $scan['count'],
             'affected_devices' => $scan['sample'],
-            'metadata_changes' => collect(['name', 'note', 'enabled', 'is_default', 'enforce'])
+            'metadata_changes' => collect(['name', 'note', 'enabled', 'is_default', 'enforce', 'confirmation_timeout_minutes'])
                 ->filter(fn (string $key) => $before[$key] !== $snapshot[$key])
                 ->mapWithKeys(fn (string $key) => [$key => [
                     'before' => $before[$key],
@@ -74,7 +75,70 @@ class StrategyImpact
         ];
     }
 
-    /** @return array{name:?string,note:?string,enabled:bool,is_default:bool,enforce:bool,options:array<string,string>} */
+    /**
+     * Stream the exact frozen target set for a reviewed rollout without holding
+     * the fleet in memory. Callers must hold the shared strategy lock first.
+     *
+     * @param  array<string,mixed>  $proposed
+     * @return \Generator<int,int>
+     */
+    public static function affectedDeviceIds(Strategy $strategy, array $proposed): \Generator
+    {
+        $before = self::snapshot($strategy);
+        $afterOptions = Strategy::sanitizeOptions(is_array($proposed['options'] ?? null) ? $proposed['options'] : []);
+        $policyChanged = $before['options'] !== $afterOptions
+            || $before['enabled'] !== (bool) ($proposed['enabled'] ?? false)
+            || $before['is_default'] !== (bool) ($proposed['is_default'] ?? false)
+            || $before['enforce'] !== (bool) ($proposed['enforce'] ?? false);
+        if (! $policyChanged) {
+            return;
+        }
+
+        $targetId = (int) $strategy->id;
+        $strategies = Strategy::query()->orderBy('id')->get(['id', 'enabled', 'is_default']);
+        $enabled = $strategies->mapWithKeys(fn (Strategy $item) => [(int) $item->id => (bool) $item->enabled])->all();
+        $enabled[$targetId] = (bool) ($proposed['enabled'] ?? false);
+        $defaultId = (($proposed['enabled'] ?? false) && ($proposed['is_default'] ?? false))
+            ? $targetId
+            : $strategies->first(fn (Strategy $item) => $item->id !== $targetId && $item->enabled && $item->is_default)?->id;
+
+        $lastId = 0;
+        while (true) {
+            $devices = Device::query()->where('status', Device::STATUS_ACTIVE)
+                ->where('id', '>', $lastId)->orderBy('id')->limit(500)->get();
+            if ($devices->isEmpty()) {
+                break;
+            }
+            $lastId = (int) $devices->last()->id;
+            $deviceIds = $devices->pluck('id')->all();
+            $userIds = $devices->pluck('user_id')->filter()->unique()->all();
+            $groupIds = $devices->pluck('device_group_id')->filter()->unique()->all();
+            $direct = DB::table('device_strategy')->whereIn('device_id', $deviceIds)->pluck('strategy_id', 'device_id')->all();
+            $owners = $userIds === [] ? [] : DB::table('strategy_user')->whereIn('user_id', $userIds)->pluck('strategy_id', 'user_id')->all();
+            $groups = $groupIds === [] ? [] : DB::table('device_group_strategy')->whereIn('device_group_id', $groupIds)->pluck('strategy_id', 'device_group_id')->all();
+
+            foreach ($devices as $device) {
+                $winner = null;
+                foreach ([
+                    $direct[$device->id] ?? null,
+                    $device->user_id === null ? null : ($owners[$device->user_id] ?? null),
+                    $device->device_group_id === null ? null : ($groups[$device->device_group_id] ?? null),
+                    $defaultId,
+                ] as $candidate) {
+                    if ($candidate !== null && ($enabled[(int) $candidate] ?? false)) {
+                        $winner = (int) $candidate;
+                        break;
+                    }
+                }
+                $current = $device->strategy_id_resolved === null ? null : (int) $device->strategy_id_resolved;
+                if ($winner !== $current || $winner === $targetId) {
+                    yield (int) $device->id;
+                }
+            }
+        }
+    }
+
+    /** @return array{name:?string,note:?string,enabled:bool,is_default:bool,enforce:bool,confirmation_timeout_minutes:int,options:array<string,string>} */
     private static function snapshot(?Strategy $strategy): array
     {
         return $strategy === null ? [
@@ -83,6 +147,7 @@ class StrategyImpact
             'enabled' => false,
             'is_default' => false,
             'enforce' => false,
+            'confirmation_timeout_minutes' => 15,
             'options' => [],
         ] : [
             'name' => $strategy->name,
@@ -90,6 +155,7 @@ class StrategyImpact
             'enabled' => (bool) $strategy->enabled,
             'is_default' => (bool) $strategy->is_default,
             'enforce' => (bool) $strategy->enforce,
+            'confirmation_timeout_minutes' => (int) $strategy->confirmation_timeout_minutes,
             'options' => $strategy->optionMap(),
         ];
     }
@@ -104,11 +170,11 @@ class StrategyImpact
         ], JSON_THROW_ON_ERROR));
 
         $targetId = $strategy?->id ?? -1;
-        $strategies = Strategy::query()->orderBy('id')->get(['id', 'name', 'enabled', 'is_default', 'enforce', 'options']);
+        $strategies = Strategy::query()->orderBy('id')->get(['id', 'name', 'enabled', 'is_default', 'enforce', 'confirmation_timeout_minutes', 'options']);
         $enabled = $strategies->mapWithKeys(fn (Strategy $item) => [(int) $item->id => (bool) $item->enabled])->all();
         $enabled[$targetId] = (bool) $proposed['enabled'];
         foreach ($strategies as $item) {
-            hash_update($hash, 'strategy:'.$item->id.':'.$item->name.':'.(int) $item->enabled.':'.(int) $item->is_default.':'.(int) $item->enforce.':'.json_encode($item->optionMap(), JSON_THROW_ON_ERROR).';');
+            hash_update($hash, 'strategy:'.$item->id.':'.$item->name.':'.(int) $item->enabled.':'.(int) $item->is_default.':'.(int) $item->enforce.':'.(int) $item->confirmation_timeout_minutes.':'.json_encode($item->optionMap(), JSON_THROW_ON_ERROR).';');
         }
 
         $defaultId = ($proposed['enabled'] && $proposed['is_default'])

--- a/database/migrations/2026_08_24_000010_create_strategy_revision_history.php
+++ b/database/migrations/2026_08_24_000010_create_strategy_revision_history.php
@@ -1,0 +1,100 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $decodeLegacyOptions = static function (object $strategy): array {
+            try {
+                $rawOptions = $strategy->options === null ? '[]' : (string) $strategy->options;
+                $options = json_decode($rawOptions, true, 512, JSON_THROW_ON_ERROR);
+            } catch (JsonException $exception) {
+                throw new RuntimeException(
+                    "Cannot create a baseline revision for strategy {$strategy->id}: options contains invalid JSON.",
+                    previous: $exception,
+                );
+            }
+
+            if (! is_array($options) || ($options !== [] && array_is_list($options))) {
+                throw new RuntimeException(
+                    "Cannot create a baseline revision for strategy {$strategy->id}: options must be a JSON object.",
+                );
+            }
+
+            return $options;
+        };
+
+        // Validate every legacy row before the first schema mutation. DDL is not
+        // reliably transactional across supported engines, so a bad row must
+        // leave this migration completely retryable.
+        DB::table('strategies')->orderBy('id')->cursor()->each($decodeLegacyOptions);
+
+        Schema::table('strategies', function (Blueprint $table) {
+            $table->softDeletes();
+        });
+
+        Schema::create('strategy_revisions', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('strategy_id')->constrained()->restrictOnDelete();
+            $table->unsignedInteger('revision');
+            $table->json('snapshot');
+            $table->string('change_note', 500)->nullable();
+            $table->foreignId('created_by')->nullable()->constrained('users')->nullOnDelete();
+            $table->string('created_by_name')->nullable();
+            $table->unsignedInteger('affected_devices')->default(0);
+            $table->timestamps();
+            $table->unique(['strategy_id', 'revision']);
+        });
+
+        Schema::table('strategies', function (Blueprint $table) {
+            $table->foreignId('active_revision_id')
+                ->nullable()
+                ->after('options')
+                ->constrained('strategy_revisions')
+                ->nullOnDelete();
+        });
+
+        // Existing strategies become revision 1 without changing their live
+        // behavior. Keep the decoder here as defense in depth after preflight.
+        DB::table('strategies')->orderBy('id')->each(function (object $strategy) use ($decodeLegacyOptions): void {
+            $revisionId = DB::table('strategy_revisions')->insertGetId([
+                'strategy_id' => $strategy->id,
+                'revision' => 1,
+                'snapshot' => json_encode([
+                    'name' => $strategy->name,
+                    'note' => $strategy->note,
+                    'enabled' => (bool) $strategy->enabled,
+                    'is_default' => (bool) $strategy->is_default,
+                    'enforce' => (bool) $strategy->enforce,
+                    'options' => $decodeLegacyOptions($strategy),
+                ], JSON_THROW_ON_ERROR),
+                'change_note' => 'Baseline created during strategy revision history upgrade',
+                'created_by' => null,
+                'created_by_name' => null,
+                'affected_devices' => DB::table('devices')->where('strategy_id_resolved', $strategy->id)->count(),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+
+            DB::table('strategies')->where('id', $strategy->id)->update(['active_revision_id' => $revisionId]);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('strategies', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('active_revision_id');
+        });
+
+        Schema::dropIfExists('strategy_revisions');
+
+        Schema::table('strategies', function (Blueprint $table) {
+            $table->dropSoftDeletes();
+        });
+    }
+};

--- a/database/migrations/2026_08_24_000020_add_strategy_rollout_foundation.php
+++ b/database/migrations/2026_08_24_000020_add_strategy_rollout_foundation.php
@@ -1,0 +1,68 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('strategies', function (Blueprint $table): void {
+            $table->unsignedSmallInteger('confirmation_timeout_minutes')->default(15)->after('active_revision_id');
+        });
+
+        Schema::table('devices', function (Blueprint $table): void {
+            $table->boolean('strategy_rollout_ack_pending')->default(false)->after('strategy_acked_at');
+        });
+
+        Schema::create('strategy_rollouts', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('strategy_id')->constrained()->restrictOnDelete();
+            $table->foreignId('strategy_revision_id')->constrained('strategy_revisions')->restrictOnDelete();
+            $table->string('status', 16)->index();
+            $table->timestamp('starts_at')->nullable()->index();
+            $table->unsignedInteger('batch_size')->default(25);
+            $table->unsignedInteger('interval_minutes')->default(15);
+            $table->timestamp('next_release_at')->nullable()->index();
+            $table->foreignId('created_by')->nullable()->constrained('users')->nullOnDelete();
+            $table->foreignId('paused_by')->nullable()->constrained('users')->nullOnDelete();
+            $table->timestamp('paused_at')->nullable();
+            $table->timestamp('completed_at')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('strategy_rollout_devices', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('strategy_rollout_id')->constrained('strategy_rollouts')->cascadeOnDelete();
+            $table->foreignId('device_id')->nullable()->constrained()->nullOnDelete();
+            $table->string('device_rustdesk_id')->nullable();
+            $table->unsignedInteger('position');
+            $table->timestamp('released_at')->nullable()->index();
+            $table->unsignedBigInteger('delivered_version')->nullable()->index();
+            $table->timestamp('delivered_at')->nullable();
+            $table->timestamp('confirmed_at')->nullable();
+            $table->timestamp('timed_out_at')->nullable();
+            $table->timestamps();
+            $table->unique(['strategy_rollout_id', 'device_id']);
+            $table->index(['strategy_rollout_id', 'position']);
+            $table->index(['strategy_rollout_id', 'confirmed_at']);
+            $table->index(['strategy_rollout_id', 'timed_out_at']);
+            $table->index(['device_id', 'delivered_version', 'confirmed_at'], 'srd_device_version_confirmed_idx');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('strategy_rollout_devices');
+        Schema::dropIfExists('strategy_rollouts');
+
+        Schema::table('devices', function (Blueprint $table): void {
+            $table->dropColumn('strategy_rollout_ack_pending');
+        });
+
+        Schema::table('strategies', function (Blueprint $table): void {
+            $table->dropColumn('confirmation_timeout_minutes');
+        });
+    }
+};

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true">
+    <testsuites>
+        <testsuite name="Feature">
+            <directory>tests/Feature</directory>
+        </testsuite>
+    </testsuites>
+    <source>
+        <include><directory>app</directory></include>
+    </source>
+    <php>
+        <env name="APP_ENV" value="testing" force="true"/>
+        <env name="APP_KEY" value="base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=" force="true"/>
+        <env name="APP_MAINTENANCE_DRIVER" value="file" force="true"/>
+        <env name="BCRYPT_ROUNDS" value="4" force="true"/>
+        <env name="CACHE_STORE" value="array" force="true"/>
+        <env name="DB_CONNECTION" value="sqlite"/>
+        <env name="DB_DATABASE" value=":memory:"/>
+        <env name="MAIL_MAILER" value="array" force="true"/>
+        <env name="PULSE_ENABLED" value="false" force="true"/>
+        <env name="QUEUE_CONNECTION" value="sync" force="true"/>
+        <env name="SESSION_DRIVER" value="array" force="true"/>
+        <env name="TELESCOPE_ENABLED" value="false" force="true"/>
+    </php>
+</phpunit>

--- a/resources/views/livewire/device-list.blade.php
+++ b/resources/views/livewire/device-list.blade.php
@@ -537,7 +537,7 @@
                             @if ($editingId !== 0 && auth()->user()?->is_admin && $strategyExplain)
                                 <hr class="my-3">
                                 <label class="form-label" for="dl-strategy">Strategy</label>
-                                <select id="dl-strategy" class="form-select" wire:model="formStrategyId">
+                                <select id="dl-strategy" class="form-select" wire:model="formStrategyId" disabled aria-describedby="dl-strategy-help">
                                     <option value="0">Inherit (owner, group, or default)</option>
                                     @foreach ($strategies as $s)
                                         <option value="{{ $s->id }}">
@@ -545,6 +545,8 @@
                                         </option>
                                     @endforeach
                                 </select>
+                                <div id="dl-strategy-help" class="form-text">Change direct assignments from Strategies → Assign to review the affected-device impact first.</div>
+                                @error('formStrategyId') <div class="invalid-feedback d-block">{{ $message }}</div> @enderror
                                 <div class="form-text">A strategy set here wins over the owner's, the group's and the default.</div>
 
                                 <div class="mt-2 rd-inset">

--- a/resources/views/livewire/strategy-list.blade.php
+++ b/resources/views/livewire/strategy-list.blade.php
@@ -78,7 +78,9 @@
                             </td>
                             <td class="text-end rd-rowact">
                                 <button type="button" class="btn btn-link btn-sm p-0 me-2 rd-act" wire:click="showHistory({{ $strategy->id }})">History</button>
-                                <button type="button" class="btn btn-link btn-sm p-0 me-2 rd-act" wire:click="openAssign({{ $strategy->id }})">Assign</button>
+                                @if ($canAssignFleet)
+                                    <button type="button" class="btn btn-link btn-sm p-0 me-2 rd-act" wire:click="openAssign({{ $strategy->id }})">Assign</button>
+                                @endif
                                 <button type="button" class="btn btn-link btn-sm p-0 me-2 rd-act" wire:click="edit({{ $strategy->id }})">Edit</button>
                                 <button type="button" class="btn btn-link btn-sm p-0 text-danger"
                                    wire:click="deleteStrategy({{ $strategy->id }})"
@@ -136,8 +138,10 @@
                                 <div class="rd-mini-acts">
                                     <button type="button" class="rd-iconbtn border-0" title="Revision history" aria-label="Revision history for {{ $strategy->name }}"
                                        wire:click="showHistory({{ $strategy->id }})"><i class="ri-history-line"></i></button>
-                                    <button type="button" class="rd-iconbtn border-0" title="Assign" aria-label="Assign {{ $strategy->name }}"
-                                       wire:click="openAssign({{ $strategy->id }})"><i class="ri-links-line"></i></button>
+                                    @if ($canAssignFleet)
+                                        <button type="button" class="rd-iconbtn border-0" title="Assign" aria-label="Assign {{ $strategy->name }}"
+                                           wire:click="openAssign({{ $strategy->id }})"><i class="ri-links-line"></i></button>
+                                    @endif
                                     <button type="button" class="rd-iconbtn border-0" title="Edit" aria-label="Edit {{ $strategy->name }}"
                                        wire:click="edit({{ $strategy->id }})"><i class="ri-pencil-line"></i></button>
                                     <button type="button" class="rd-iconbtn border-0 text-danger" title="Delete" aria-label="Delete {{ $strategy->name }}"
@@ -157,12 +161,12 @@
     </div>
 
     {{-- Create / edit modal --}}
-    @if ($editingId !== null)
+    @if ($editingId !== null && ! $previewing)
         <div class="modal fade show d-block" tabindex="-1" role="dialog" aria-modal="true"
              style="background: rgba(0,0,0,.6);" wire:key="strategy-editor">
             <div class="modal-dialog modal-lg modal-dialog-centered modal-dialog-scrollable">
                 <div class="modal-content">
-                    <form wire:submit="save">
+                    <form wire:submit="previewSave">
                         <div class="modal-header">
                             <h5 class="modal-title">{{ $editingId === 0 ? 'Add Strategy' : 'Edit Strategy' }}</h5>
                             <button type="button" class="btn-close" wire:click="closeModal" aria-label="Close"></button>
@@ -248,8 +252,8 @@
                         <div class="modal-footer">
                             <button type="button" class="btn btn-light" wire:click="closeModal">Cancel</button>
                             <button type="submit" class="btn btn-primary">
-                                <span wire:loading.remove wire:target="save">{{ $editingId === 0 ? 'Create Strategy' : 'Save Changes' }}</span>
-                                <span wire:loading wire:target="save">Saving…</span>
+                                <span wire:loading.remove wire:target="previewSave">Review Impact</span>
+                                <span wire:loading wire:target="previewSave">Calculating…</span>
                             </button>
                         </div>
                     </form>
@@ -259,8 +263,74 @@
         <div class="modal-backdrop fade show"></div>
     @endif
 
+    {{-- Policy impact preview --}}
+    @if ($previewing && $editingId !== null)
+        <div class="modal fade show d-block" tabindex="-1" role="dialog" aria-modal="true"
+             aria-labelledby="strategy-impact-title" style="background: rgba(0,0,0,.72); z-index: 1080;" wire:key="strategy-impact-preview">
+            <div class="modal-dialog modal-lg modal-dialog-centered modal-dialog-scrollable">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <div>
+                            <h5 class="modal-title" id="strategy-impact-title">
+                                {{ $pendingDeleteId ? 'Review strategy deletion' : ($restoreRevisionId ? 'Review revision restore' : 'Review strategy impact') }}
+                            </h5>
+                            <small class="text-muted">Nothing has been changed yet.</small>
+                        </div>
+                        <button type="button" class="btn-close" wire:click="closePreview" aria-label="Back to editor"></button>
+                    </div>
+                    <div class="modal-body">
+                        @error('preview') <div class="alert alert-danger" role="alert">{{ $message }}</div> @enderror
+                        @if ($pendingDeleteId)
+                            <div class="alert alert-danger"><strong>This strategy will be deleted.</strong> Its immutable revision history remains available in storage, while direct assignments are released.</div>
+                        @elseif ($restoreRevisionId)
+                            <div class="alert alert-warning"><strong>This restore creates a new revision.</strong> The historical row itself remains unchanged.</div>
+                        @endif
+                        <div class="alert alert-info"><strong>{{ $impactPreview['affected_count'] ?? 0 }} device(s)</strong> will receive a different effective strategy or policy.</div>
+                        @if (!empty($impactPreview['dangerous']))
+                            <div class="alert alert-warning"><strong>High-impact controls</strong><ul class="mb-0 mt-1">
+                                @foreach ($impactPreview['dangerous'] as $warning)
+                                    <li><code>{{ $warning['key'] }}</code> changes to <strong>{{ $warning['after'] }}</strong>.</li>
+                                @endforeach
+                            </ul></div>
+                        @endif
+                        @if (!empty($impactPreview['resets']))
+                            <div class="alert alert-warning"><strong>{{ count($impactPreview['resets']) }} managed option(s) will reset to the client default:</strong> {{ implode(', ', $impactPreview['resets']) }}</div>
+                        @endif
+                        <h6>Policy diff</h6>
+                        <div class="table-responsive mb-3"><table class="table table-sm mb-0">
+                            <thead><tr><th>Setting</th><th>Before</th><th>After</th></tr></thead><tbody>
+                            @forelse (($impactPreview['option_changes'] ?? []) as $key => $change)
+                                <tr><td><code>{{ $key }}</code></td><td>{{ $change['before'] ?? 'Not managed' }}</td><td>{{ $change['after'] ?? 'Not managed' }}</td></tr>
+                            @empty
+                                <tr><td colspan="3" class="text-muted">No option changes.</td></tr>
+                            @endforelse
+                            @foreach (($impactPreview['metadata_changes'] ?? []) as $key => $change)
+                                <tr><td>{{ str_replace('_', ' ', ucfirst($key)) }}</td><td>{{ is_bool($change['before']) ? ($change['before'] ? 'Yes' : 'No') : ($change['before'] ?? '—') }}</td><td>{{ is_bool($change['after']) ? ($change['after'] ? 'Yes' : 'No') : ($change['after'] ?? '—') }}</td></tr>
+                            @endforeach
+                            </tbody>
+                        </table></div>
+                        @if (!empty($impactPreview['affected_devices']))
+                            <details><summary class="fw-semibold">Affected-device sample (up to 50)</summary><div class="d-flex flex-wrap gap-1 mt-2">
+                                @foreach ($impactPreview['affected_devices'] as $device)
+                                    <span class="badge bg-secondary-subtle text-secondary">{{ $device['rustdesk_id'] }} · {{ $device['label'] }} @if ($device['winning_level']) · {{ str_replace('_', ' ', $device['winning_level']) }} @endif</span>
+                                @endforeach
+                            </div></details>
+                        @endif
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-light me-auto" wire:click="closePreview">Back</button>
+                        <button type="button" class="btn btn-primary" wire:click="confirmSave">
+                            <span wire:loading.remove wire:target="confirmSave">{{ $pendingDeleteId ? 'Delete strategy' : ($restoreRevisionId ? 'Restore revision' : 'Apply strategy') }}</span>
+                            <span wire:loading wire:target="confirmSave">Applying…</span>
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    @endif
+
     {{-- Assignment modal --}}
-    @if ($assigning)
+    @if ($assigning && ! $assignPreviewing)
         <div class="modal fade show d-block" tabindex="-1" role="dialog" aria-modal="true"
              style="background: rgba(0,0,0,.6);" wire:key="strategy-assign">
             <div class="modal-dialog modal-lg modal-dialog-centered modal-dialog-scrollable">
@@ -403,15 +473,61 @@
                     </div>
                     <div class="modal-footer">
                         <button type="button" class="btn btn-light" wire:click="closeAssign">Cancel</button>
-                        <button type="button" class="btn btn-primary" wire:click="saveAssign">
-                            <span wire:loading.remove wire:target="saveAssign">Save Assignment</span>
-                            <span wire:loading wire:target="saveAssign">Saving…</span>
+                        <button type="button" class="btn btn-primary" wire:click="previewAssign">
+                            <span wire:loading.remove wire:target="previewAssign">Review Assignment Impact</span>
+                            <span wire:loading wire:target="previewAssign">Calculating…</span>
                         </button>
                     </div>
                 </div>
             </div>
         </div>
         <div class="modal-backdrop fade show"></div>
+    @endif
+
+    {{-- Assignment impact preview --}}
+    @if ($assignPreviewing && $assigning)
+        <div class="modal fade show d-block" tabindex="-1" role="dialog" aria-modal="true"
+             aria-labelledby="assignment-impact-title" style="background: rgba(0,0,0,.72); z-index: 1080;" wire:key="assignment-impact-preview">
+            <div class="modal-dialog modal-lg modal-dialog-centered modal-dialog-scrollable">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <div>
+                            <h5 class="modal-title" id="assignment-impact-title">Review assignment impact</h5>
+                            <small class="text-muted">Nothing has been reassigned yet.</small>
+                        </div>
+                        <button type="button" class="btn-close" wire:click="closeAssignPreview" aria-label="Back to assignments"></button>
+                    </div>
+                    <div class="modal-body">
+                        @error('assignment') <div class="alert alert-danger" role="alert">{{ $message }}</div> @enderror
+                        <div class="alert alert-info"><strong>{{ $assignmentImpact['affected_count'] ?? 0 }} device(s)</strong> will resolve to a different strategy.</div>
+                        <div class="row g-2 mb-3">
+                            @foreach (['device' => 'Direct devices', 'user' => 'Users', 'device_group' => 'Device groups'] as $level => $label)
+                                @php($change = $assignmentImpact['assignment_changes'][$level] ?? ['added_count' => 0, 'removed_count' => 0])
+                                <div class="col-12 col-md-4"><div class="card border h-100"><div class="card-body py-2">
+                                    <strong>{{ $label }}</strong><div class="text-success">+ {{ $change['added_count'] }}</div><div class="text-danger">− {{ $change['removed_count'] }}</div>
+                                </div></div></div>
+                            @endforeach
+                        </div>
+                        <div class="table-responsive"><table class="table table-sm align-middle">
+                            <thead><tr><th>Device</th><th>Before</th><th>After</th><th>Winning level</th></tr></thead><tbody>
+                            @forelse (($assignmentImpact['affected_devices'] ?? []) as $device)
+                                <tr><td><strong>{{ $device['rustdesk_id'] }}</strong><small class="text-muted d-block">{{ $device['label'] }}</small></td><td>{{ $device['before_strategy'] }}</td><td>{{ $device['after_strategy'] }}</td><td class="text-capitalize">{{ str_replace('_', ' ', $device['winning_level'] ?? 'none') }}</td></tr>
+                            @empty
+                                <tr><td colspan="4" class="text-center text-muted py-3">No device changes. Only assignment metadata will change.</td></tr>
+                            @endforelse
+                            </tbody>
+                        </table></div>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-light me-auto" wire:click="closeAssignPreview">Back</button>
+                        <button type="button" class="btn btn-primary" wire:click="confirmAssign">
+                            <span wire:loading.remove wire:target="confirmAssign">Apply assignments</span>
+                            <span wire:loading wire:target="confirmAssign">Applying…</span>
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
     @endif
 
     {{-- Immutable revision history and comparison --}}

--- a/resources/views/livewire/strategy-list.blade.php
+++ b/resources/views/livewire/strategy-list.blade.php
@@ -77,11 +77,12 @@
                                 </div>
                             </td>
                             <td class="text-end rd-rowact">
-                                <a href="javascript:void(0);" class="rd-act me-2" wire:click="openAssign({{ $strategy->id }})">Assign</a>
-                                <a href="javascript:void(0);" class="rd-act me-2" wire:click="edit({{ $strategy->id }})">Edit</a>
-                                <a href="javascript:void(0);" class="text-danger"
+                                <button type="button" class="btn btn-link btn-sm p-0 me-2 rd-act" wire:click="showHistory({{ $strategy->id }})">History</button>
+                                <button type="button" class="btn btn-link btn-sm p-0 me-2 rd-act" wire:click="openAssign({{ $strategy->id }})">Assign</button>
+                                <button type="button" class="btn btn-link btn-sm p-0 me-2 rd-act" wire:click="edit({{ $strategy->id }})">Edit</button>
+                                <button type="button" class="btn btn-link btn-sm p-0 text-danger"
                                    wire:click="deleteStrategy({{ $strategy->id }})"
-                                   wire:confirm="Delete strategy {{ $strategy->name }}? Devices assigned to it fall back to the default strategy, and the options it pushed are reset to the client defaults on the next heartbeat.">Delete</a>
+                                   wire:confirm="Delete strategy {{ $strategy->name }}? Devices assigned to it fall back to the default strategy, and the options it pushed are reset to the client defaults on the next heartbeat.">Delete</button>
                             </td>
                         </tr>
                     @empty
@@ -133,13 +134,15 @@
                                     <i class="ri-folder-line ms-2 me-1"></i>{{ $strategy->device_groups_count }}
                                 </span>
                                 <div class="rd-mini-acts">
-                                    <a href="javascript:void(0);" class="rd-iconbtn" title="Assign"
-                                       wire:click="openAssign({{ $strategy->id }})"><i class="ri-links-line"></i></a>
-                                    <a href="javascript:void(0);" class="rd-iconbtn" title="Edit"
-                                       wire:click="edit({{ $strategy->id }})"><i class="ri-pencil-line"></i></a>
-                                    <a href="javascript:void(0);" class="rd-iconbtn text-danger" title="Delete"
+                                    <button type="button" class="rd-iconbtn border-0" title="Revision history" aria-label="Revision history for {{ $strategy->name }}"
+                                       wire:click="showHistory({{ $strategy->id }})"><i class="ri-history-line"></i></button>
+                                    <button type="button" class="rd-iconbtn border-0" title="Assign" aria-label="Assign {{ $strategy->name }}"
+                                       wire:click="openAssign({{ $strategy->id }})"><i class="ri-links-line"></i></button>
+                                    <button type="button" class="rd-iconbtn border-0" title="Edit" aria-label="Edit {{ $strategy->name }}"
+                                       wire:click="edit({{ $strategy->id }})"><i class="ri-pencil-line"></i></button>
+                                    <button type="button" class="rd-iconbtn border-0 text-danger" title="Delete" aria-label="Delete {{ $strategy->name }}"
                                        wire:click="deleteStrategy({{ $strategy->id }})"
-                                       wire:confirm="Delete strategy {{ $strategy->name }}? Devices assigned to it fall back to the default strategy."><i class="ri-delete-bin-line"></i></a>
+                                       wire:confirm="Delete strategy {{ $strategy->name }}? Devices assigned to it fall back to the default strategy."><i class="ri-delete-bin-line"></i></button>
                                 </div>
                             </div>
                     </div>
@@ -405,6 +408,80 @@
                             <span wire:loading wire:target="saveAssign">Saving…</span>
                         </button>
                     </div>
+                </div>
+            </div>
+        </div>
+        <div class="modal-backdrop fade show"></div>
+    @endif
+
+    {{-- Immutable revision history and comparison --}}
+    @if ($historyStrategy)
+        <div class="modal fade show d-block" tabindex="-1" role="dialog" aria-modal="true"
+             aria-labelledby="strategy-history-title" wire:keydown.escape.window="closeHistory"
+             style="background: rgba(0,0,0,.65);" wire:key="strategy-history">
+            <div class="modal-dialog modal-xl modal-dialog-centered modal-dialog-scrollable">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <div>
+                            <h5 class="modal-title" id="strategy-history-title">{{ $historyStrategy->name }} revision history</h5>
+                            <small class="text-muted">Restoring creates a new revision; existing history is never rewritten.</small>
+                        </div>
+                        <button type="button" class="btn-close" wire:click="closeHistory" aria-label="Close history"></button>
+                    </div>
+                    <div class="modal-body">
+                        @error('history') <div class="alert alert-danger" role="alert">{{ $message }}</div> @enderror
+                        @if ($revisionHistory->isNotEmpty())
+                            <div class="row g-2 align-items-end mb-3">
+                                <div class="col-12 col-md-5">
+                                    <label class="form-label" for="compare-from">Compare from</label>
+                                    <select id="compare-from" class="form-select" wire:model.live="compareFromRevisionId">
+                                        <option value="">Choose revision</option>
+                                        @foreach ($revisionHistory->sortBy('revision') as $revision)
+                                            <option value="{{ $revision->id }}">Revision {{ $revision->revision }}</option>
+                                        @endforeach
+                                    </select>
+                                </div>
+                                <div class="col-12 col-md-5">
+                                    <label class="form-label" for="compare-to">Compare to</label>
+                                    <select id="compare-to" class="form-select" wire:model.live="compareToRevisionId">
+                                        <option value="">Choose revision</option>
+                                        @foreach ($revisionHistory->sortBy('revision') as $revision)
+                                            <option value="{{ $revision->id }}">Revision {{ $revision->revision }}</option>
+                                        @endforeach
+                                    </select>
+                                </div>
+                            </div>
+                            @if ($compareFromRevisionId && $compareToRevisionId)
+                                <div class="table-responsive mb-4">
+                                    <table class="table table-sm"><thead><tr><th>Field</th><th>From</th><th>To</th></tr></thead><tbody>
+                                    @forelse ($revisionComparison as $change)
+                                        <tr><td><code>{{ $change['key'] }}</code></td><td>{{ is_bool($change['before']) ? ($change['before'] ? 'Yes' : 'No') : ($change['before'] ?? 'Not managed') }}</td><td>{{ is_bool($change['after']) ? ($change['after'] ? 'Yes' : 'No') : ($change['after'] ?? 'Not managed') }}</td></tr>
+                                    @empty
+                                        <tr><td colspan="3" class="text-muted">These revisions are identical.</td></tr>
+                                    @endforelse
+                                    </tbody></table>
+                                </div>
+                            @endif
+                            <div class="list-group">
+                                @foreach ($revisionHistory as $revision)
+                                    <div class="list-group-item d-flex flex-column flex-md-row justify-content-between gap-2" wire:key="revision-{{ $revision->id }}">
+                                        <div>
+                                            <strong>Revision {{ $revision->revision }}</strong>
+                                            @if ($historyStrategy->active_revision_id === $revision->id)<span class="badge bg-success-subtle text-success ms-1">Active</span>@endif
+                                            <div class="text-muted fs-13">{{ $revision->created_by_name ?? $revision->creator?->username ?? 'System' }} · {{ $revision->created_at->timezone(config('app.timezone'))->format('M j, Y g:i A T') }} · {{ $revision->affected_devices }} affected device(s)</div>
+                                            @if ($revision->change_note)<div class="mt-1">{{ $revision->change_note }}</div>@endif
+                                        </div>
+                                        @if ($historyStrategy->active_revision_id !== $revision->id)
+                                            <button type="button" class="btn btn-sm btn-outline-warning align-self-md-center" wire:click="restoreRevision({{ $revision->id }})" wire:confirm="Restore revision {{ $revision->revision }} as a new revision?">Restore as new revision</button>
+                                        @endif
+                                    </div>
+                                @endforeach
+                            </div>
+                        @else
+                            <div class="text-muted">No revisions have been captured yet.</div>
+                        @endif
+                    </div>
+                    <div class="modal-footer"><button type="button" class="btn btn-light" wire:click="closeHistory">Close</button></div>
                 </div>
             </div>
         </div>

--- a/resources/views/livewire/strategy-list.blade.php
+++ b/resources/views/livewire/strategy-list.blade.php
@@ -22,6 +22,44 @@
                 </div>
             @endif
 
+            @if ($rollouts->isNotEmpty())
+                <div class="px-3 pb-3">
+                    <div class="border rounded overflow-hidden">
+                        <div class="d-flex justify-content-between align-items-center px-3 py-2 bg-light">
+                            <strong>Recent staged rollouts</strong>
+                            <small class="text-muted">Frozen targets · immutable revision</small>
+                        </div>
+                        <div class="table-responsive">
+                            <table class="table table-sm align-middle mb-0">
+                                <thead><tr><th>Strategy</th><th>Status</th><th>Released</th><th>Confirmed</th><th>Timed out</th><th>Next batch</th><th class="text-end">Action</th></tr></thead>
+                                <tbody>
+                                @foreach ($rollouts as $rollout)
+                                    <tr wire:key="rollout-{{ $rollout->id }}">
+                                        <td><strong>{{ $rollout->strategy?->name ?? 'Deleted strategy' }}</strong><small class="text-muted d-block">Revision {{ $rollout->revision?->revision ?? '—' }} · {{ $rollout->target_count }} target(s)</small></td>
+                                        <td><span class="badge bg-secondary-subtle text-secondary">{{ ucfirst($rollout->status) }}</span></td>
+                                        <td>{{ $rollout->released_count }} / {{ $rollout->target_count }}</td>
+                                        <td>{{ $rollout->confirmed_count }} / {{ $rollout->target_count }}</td>
+                                        <td>{{ $rollout->timed_out_count }}</td>
+                                        <td>{{ $rollout->next_release_at?->format('M j, Y g:i A') ?? '—' }}</td>
+                                        <td class="text-end text-nowrap">
+                                            @if ($rollout->status === \App\Models\StrategyRollout::STATUS_ACTIVE)
+                                                <button type="button" class="btn btn-sm btn-outline-warning" wire:click="pauseRollout({{ $rollout->id }})">Pause</button>
+                                            @elseif ($rollout->status === \App\Models\StrategyRollout::STATUS_PAUSED)
+                                                <button type="button" class="btn btn-sm btn-outline-primary" wire:click="resumeRollout({{ $rollout->id }})">Resume</button>
+                                            @endif
+                                            @if ($rollout->released_count === 0 && in_array($rollout->status, [\App\Models\StrategyRollout::STATUS_SCHEDULED, \App\Models\StrategyRollout::STATUS_PAUSED], true))
+                                                <button type="button" class="btn btn-sm btn-outline-danger" wire:click="cancelRollout({{ $rollout->id }})" wire:confirm="Cancel this rollout before any devices receive it?">Cancel</button>
+                                            @endif
+                                        </td>
+                                    </tr>
+                                @endforeach
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+            @endif
+
             {{-- Desktop table (md and up) --}}
             <div class="table-responsive d-none d-md-block">
                 <table class="table table-hover table-centered mb-0">
@@ -211,6 +249,17 @@
                                 </div>
                             </div>
 
+                            <div class="row mb-3">
+                                <div class="col-12 col-md-6">
+                                    <label class="form-label" for="sl-confirmation-timeout">Confirmation timeout (minutes)</label>
+                                    <input id="sl-confirmation-timeout" type="number" min="1" max="1440"
+                                           class="form-control @error('formConfirmationTimeout') is-invalid @enderror"
+                                           wire:model="formConfirmationTimeout">
+                                    @error('formConfirmationTimeout') <div class="invalid-feedback">{{ $message }}</div> @enderror
+                                    <small class="text-muted">How long a released revision may remain unconfirmed before the batch records a timeout and can advance.</small>
+                                </div>
+                            </div>
+
                             <div class="alert alert-secondary py-2 fs-13 mb-3">
                                 <i class="ri-information-line me-1"></i>Controls left on <strong>Not managed</strong> are not part of this strategy: the device keeps whatever it has. Changing a managed option back to Not managed resets that option to the client's built-in default on the next heartbeat.
                             </div>
@@ -316,9 +365,48 @@
                                 @endforeach
                             </div></details>
                         @endif
+
+                        @if ($canAssignFleet && $editingId > 0 && ! $pendingDeleteId && ! $restoreRevisionId && ($impactPreview['affected_count'] ?? 0) > 0)
+                            @php
+                                $stagedBlocked = array_intersect(
+                                    array_keys($impactPreview['metadata_changes'] ?? []),
+                                    ['name', 'enabled', 'is_default', 'confirmation_timeout_minutes'],
+                                );
+                            @endphp
+                            <div class="border rounded p-3 mt-3">
+                                <h6 class="mb-1">Staged rollout</h6>
+                                <p class="text-muted fs-13">Freeze the reviewed target set, release a bounded batch now or at the selected time, then advance only after that batch confirms or times out.</p>
+                                @error('rollout') <div class="alert alert-danger py-2">{{ $message }}</div> @enderror
+                                @if ($stagedBlocked)
+                                    <div class="alert alert-warning py-2 mb-0">Apply identity, enabled/default, and confirmation-timeout changes now. Staged rollouts accept policy options, note, and enforce changes only.</div>
+                                @else
+                                    <div class="row g-2">
+                                        <div class="col-12 col-md-4">
+                                            <label class="form-label" for="sl-rollout-start">Start at</label>
+                                            <input id="sl-rollout-start" type="datetime-local" class="form-control" wire:model="rolloutStartAt">
+                                            <small class="text-muted">Blank starts now ({{ config('app.timezone') }}).</small>
+                                        </div>
+                                        <div class="col-6 col-md-4">
+                                            <label class="form-label" for="sl-rollout-batch">Batch size</label>
+                                            <input id="sl-rollout-batch" type="number" min="1" max="1000" class="form-control" wire:model="rolloutBatchSize">
+                                        </div>
+                                        <div class="col-6 col-md-4">
+                                            <label class="form-label" for="sl-rollout-interval">Interval (minutes)</label>
+                                            <input id="sl-rollout-interval" type="number" min="1" max="1440" class="form-control" wire:model="rolloutIntervalMinutes">
+                                        </div>
+                                    </div>
+                                @endif
+                            </div>
+                        @endif
                     </div>
                     <div class="modal-footer">
                         <button type="button" class="btn btn-light me-auto" wire:click="closePreview">Back</button>
+                        @if ($canAssignFleet && $editingId > 0 && ! $pendingDeleteId && ! $restoreRevisionId && ($impactPreview['affected_count'] ?? 0) > 0 && empty($stagedBlocked ?? []))
+                            <button type="button" class="btn btn-outline-primary" wire:click="scheduleRollout">
+                                <span wire:loading.remove wire:target="scheduleRollout">Schedule rollout</span>
+                                <span wire:loading wire:target="scheduleRollout">Scheduling…</span>
+                            </button>
+                        @endif
                         <button type="button" class="btn btn-primary" wire:click="confirmSave">
                             <span wire:loading.remove wire:target="confirmSave">{{ $pendingDeleteId ? 'Delete strategy' : ($restoreRevisionId ? 'Restore revision' : 'Apply strategy') }}</span>
                             <span wire:loading wire:target="confirmSave">Applying…</span>

--- a/routes/console.php
+++ b/routes/console.php
@@ -22,5 +22,8 @@ Schedule::command('cortendesk:close-stale-sessions')->everyFiveMinutes()->withou
 // Presence transitions for configurable Apprise notifications.
 Schedule::command('cortendesk:check-device-notifications')->everyMinute()->withoutOverlapping();
 
+// Advance scheduled strategy rollout batches with one host/process at a time.
+Schedule::command('cortendesk:advance-strategy-rollouts')->everyMinute()->withoutOverlapping();
+
 // Proves the scheduler is alive, for the diagnostics page.
 Schedule::command('cortendesk:diagnostics-heartbeat')->everyMinute()->withoutOverlapping();

--- a/tests/Feature/StrategyImpactPreviewTest.php
+++ b/tests/Feature/StrategyImpactPreviewTest.php
@@ -1,0 +1,386 @@
+<?php
+
+use App\Livewire\DeviceList;
+use App\Livewire\StrategyList;
+use App\Models\ApiToken;
+use App\Models\Device;
+use App\Models\DeviceGroup;
+use App\Models\GroupAccess;
+use App\Models\Role;
+use App\Models\Strategy;
+use App\Models\StrategyRevision;
+use App\Models\User;
+use App\Services\StrategyImpact;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Support\Facades\DB;
+use Livewire\Livewire;
+
+beforeEach(function () {
+    Strategy::flushCache();
+});
+
+function impactAdmin(): User
+{
+    return User::factory()->admin()->create();
+}
+
+function impactDevice(string $id, array $attributes = []): Device
+{
+    return Device::create([
+        'rustdesk_id' => $id,
+        'uuid' => 'impact-'.$id,
+        'hostname' => 'host-'.$id,
+        'status' => Device::STATUS_ACTIVE,
+        ...$attributes,
+    ]);
+}
+
+it('previews a policy save before it can mutate the strategy', function () {
+    $admin = impactAdmin();
+    $strategy = Strategy::create([
+        'name' => 'Preview policy',
+        'enabled' => true,
+        'options' => ['enable-file-transfer' => 'N'],
+    ]);
+    $device = impactDevice('981000001');
+    Strategy::assignTo(Strategy::LEVEL_DEVICE, $device->id, $strategy->id);
+
+    Livewire::actingAs($admin)
+        ->test(StrategyList::class)
+        ->call('edit', $strategy->id)
+        ->set('formOptions.enable-file-transfer', 'Y')
+        ->set('formOptions.enable-terminal', 'N')
+        ->call('save')
+        ->assertSet('previewing', true)
+        ->assertSet('impactPreview.affected_count', 1)
+        ->assertSet('impactPreview.option_changes.enable-file-transfer.before', 'N')
+        ->assertSet('impactPreview.option_changes.enable-file-transfer.after', 'Y')
+        ->assertSet('impactPreview.dangerous.0.key', 'enable-terminal')
+        ->assertSee('Review strategy impact');
+
+    expect($strategy->fresh()->optionMap())->toBe(['enable-file-transfer' => 'N']);
+});
+
+it('confirms a reviewed default change and captures both immutable revisions', function () {
+    $admin = impactAdmin();
+    $currentDefault = Strategy::create(['name' => 'Current reviewed default', 'enabled' => true, 'is_default' => true]);
+    $candidate = Strategy::create(['name' => 'Candidate reviewed default', 'enabled' => true]);
+    foreach ([$currentDefault, $candidate] as $strategy) {
+        $revision = StrategyRevision::capture($strategy, $admin->id, 'Initial');
+        $strategy->forceFill(['active_revision_id' => $revision->id])->saveQuietly();
+    }
+
+    Livewire::actingAs($admin)
+        ->test(StrategyList::class)
+        ->call('edit', $candidate->id)
+        ->set('formIsDefault', true)
+        ->call('previewSave')
+        ->call('confirmSave')
+        ->assertHasNoErrors()
+        ->assertSet('editingId', null);
+
+    expect($candidate->fresh()->is_default)->toBeTrue()
+        ->and($candidate->revisions()->count())->toBe(2)
+        ->and($currentDefault->fresh()->is_default)->toBeFalse()
+        ->and($currentDefault->revisions()->count())->toBe(2);
+});
+
+it('rejects a policy confirmation after its reviewed assignment state changes', function () {
+    $admin = impactAdmin();
+    $strategy = Strategy::create([
+        'name' => 'Reviewed policy',
+        'enabled' => true,
+        'options' => ['enable-audio' => 'N'],
+    ]);
+    $replacement = Strategy::create(['name' => 'Replacement policy', 'enabled' => true]);
+    $device = impactDevice('981000002');
+    Strategy::assignTo(Strategy::LEVEL_DEVICE, $device->id, $strategy->id);
+
+    $component = Livewire::actingAs($admin)
+        ->test(StrategyList::class)
+        ->call('edit', $strategy->id)
+        ->set('formOptions.enable-audio', 'Y')
+        ->call('previewSave')
+        ->assertSet('previewing', true);
+
+    Strategy::assignTo(Strategy::LEVEL_DEVICE, $device->id, $replacement->id);
+
+    $component->call('confirmSave')->assertHasErrors('preview');
+
+    expect($strategy->fresh()->optionMap())->toBe(['enable-audio' => 'N']);
+});
+
+it('previews default state changes against every active device', function () {
+    impactDevice('981000003');
+    impactDevice('981000004');
+
+    $preview = StrategyImpact::preview(null, [
+        'name' => 'Fleet default',
+        'note' => null,
+        'enabled' => true,
+        'is_default' => true,
+        'enforce' => false,
+        'options' => ['enable-audio' => 'N'],
+    ]);
+
+    expect($preview['affected_count'])->toBe(2)
+        ->and($preview['metadata_changes']['is_default']['after'])->toBeTrue();
+});
+
+it('rejects a disabled default before producing an impact preview', function () {
+    Livewire::actingAs(impactAdmin())
+        ->test(StrategyList::class)
+        ->call('create')
+        ->set('formName', 'Invalid disabled default')
+        ->set('formEnabled', false)
+        ->set('formIsDefault', true)
+        ->call('previewSave')
+        ->assertHasErrors('formIsDefault')
+        ->assertSet('previewing', false);
+});
+
+it('turns off default status when the quick toggle disables a strategy', function () {
+    $strategy = Strategy::create(['name' => 'Toggleable default', 'enabled' => true, 'is_default' => true]);
+
+    Livewire::actingAs(impactAdmin())
+        ->test(StrategyList::class)
+        ->call('toggleEnabled', $strategy->id)
+        ->assertSet('previewing', true)
+        ->assertSet('formEnabled', false)
+        ->assertSet('formIsDefault', false)
+        ->call('confirmSave')
+        ->assertHasNoErrors();
+
+    expect($strategy->fresh()->enabled)->toBeFalse()
+        ->and($strategy->fresh()->is_default)->toBeFalse();
+});
+
+it('previews strategy deletion before changing fleet routing', function () {
+    $strategy = Strategy::create(['name' => 'Reviewed deletion', 'enabled' => true]);
+    $device = impactDevice('981000011');
+    Strategy::assignTo(Strategy::LEVEL_DEVICE, $device->id, $strategy->id);
+
+    $component = Livewire::actingAs(impactAdmin())
+        ->test(StrategyList::class)
+        ->call('deleteStrategy', $strategy->id)
+        ->assertSet('previewing', true)
+        ->assertHasNoErrors();
+
+    expect($strategy->fresh())->not->toBeNull();
+
+    $component->call('confirmSave')->assertHasNoErrors();
+
+    expect(Strategy::find($strategy->id))->toBeNull()
+        ->and(Strategy::withTrashed()->find($strategy->id)?->trashed())->toBeTrue();
+});
+
+it('invalidates a policy fingerprint when any effective fleet policy changes', function () {
+    $strategy = Strategy::create(['name' => 'Reviewed fingerprint', 'enabled' => true]);
+    $other = Strategy::create(['name' => 'Other fleet policy', 'enabled' => true]);
+    $snapshot = [
+        'name' => 'Reviewed fingerprint',
+        'note' => null,
+        'enabled' => true,
+        'is_default' => false,
+        'enforce' => false,
+        'options' => ['enable-audio' => 'N'],
+    ];
+
+    $reviewed = StrategyImpact::preview($strategy, $snapshot);
+    $other->setOptions(['enable-file-transfer' => 'N']);
+    $other->save();
+    $current = StrategyImpact::preview($strategy->fresh(), $snapshot);
+
+    expect($current['fingerprint'])->not->toBe($reviewed['fingerprint']);
+});
+
+it('previews assignment changes before it reassigns devices', function () {
+    $admin = impactAdmin();
+    $strategy = Strategy::create(['name' => 'Assignment target', 'enabled' => true]);
+    $fallback = Strategy::create(['name' => 'Assignment fallback', 'enabled' => true, 'is_default' => true]);
+    $device = impactDevice('981000005');
+
+    Livewire::actingAs($admin)
+        ->test(StrategyList::class)
+        ->call('openAssign', $strategy->id)
+        ->set('assignDeviceIds', [$device->id])
+        ->call('saveAssign')
+        ->assertSet('assignPreviewing', true)
+        ->assertSet('assignmentImpact.affected_count', 1)
+        ->assertSet('assignmentImpact.assignment_changes.device.added_count', 1)
+        ->assertSee('Review assignment impact');
+
+    expect($device->fresh()->assignedStrategyId())->toBeNull()
+        ->and($device->fresh()->strategy_id_resolved)->toBe($fallback->id);
+});
+
+it('rejects assignment confirmation after the reviewed assignment state changes', function () {
+    $admin = impactAdmin();
+    $strategy = Strategy::create(['name' => 'Assignment review', 'enabled' => true]);
+    $replacement = Strategy::create(['name' => 'Other assignment', 'enabled' => true]);
+    $device = impactDevice('981000006');
+
+    $component = Livewire::actingAs($admin)
+        ->test(StrategyList::class)
+        ->call('openAssign', $strategy->id)
+        ->set('assignDeviceIds', [$device->id])
+        ->call('previewAssign')
+        ->assertSet('assignPreviewing', true);
+
+    Strategy::assignTo(Strategy::LEVEL_DEVICE, $device->id, $replacement->id);
+
+    $component->call('confirmAssign')->assertHasErrors('assignment');
+
+    expect($device->fresh()->assignedStrategyId())->toBe($replacement->id);
+});
+
+it('serializes owner changes through the strategy context and enforces token scope', function () {
+    $fallback = Strategy::create(['name' => 'Context fallback', 'enabled' => true, 'is_default' => true]);
+    $ownerPolicy = Strategy::create(['name' => 'Owner policy', 'enabled' => true]);
+    $owner = User::factory()->create();
+    $device = impactDevice('981000008');
+    Strategy::assignTo(Strategy::LEVEL_USER, $owner->id, $ownerPolicy->id);
+
+    expect(fn () => Device::updateWithStrategyContext($device, ['user_id' => $owner->id], false))
+        ->toThrow(AuthorizationException::class)
+        ->and($device->fresh()->user_id)->toBeNull()
+        ->and($device->fresh()->strategy_id_resolved)->toBe($fallback->id);
+
+    $device = Device::updateWithStrategyContext($device, ['user_id' => $owner->id]);
+
+    expect($device->fresh()->user_id)->toBe($owner->id)
+        ->and($device->fresh()->strategy_id_resolved)->toBe($ownerPolicy->id);
+});
+
+it('rejects API owner changes that alter policy without strategy permission', function () {
+    $creator = User::factory()->admin()->create();
+    [, $plain] = ApiToken::issue($creator, 'impact-device-only', ['device' => 'rw', 'strategy' => 'none']);
+    $fallback = Strategy::create(['name' => 'API fallback', 'enabled' => true, 'is_default' => true]);
+    $ownerPolicy = Strategy::create(['name' => 'API owner policy', 'enabled' => true]);
+    $owner = User::factory()->create();
+    $device = impactDevice('981000009');
+    Strategy::assignTo(Strategy::LEVEL_USER, $owner->id, $ownerPolicy->id);
+
+    $this->withHeaders(['Authorization' => "Bearer {$plain}", 'Accept' => 'application/json'])
+        ->postJson('/api/v1/devices/'.$device->id.'/assign', ['user_id' => $owner->id])
+        ->assertForbidden();
+
+    expect($device->fresh()->user_id)->toBeNull()
+        ->and($device->fresh()->strategy_id_resolved)->toBe($fallback->id);
+});
+
+it('rejects CLI strategy assignment without an interactive impact confirmation', function () {
+    $creator = User::factory()->admin()->create();
+    [, $plain] = ApiToken::issue($creator, 'impact-cli-strategy', ['device' => 'rw', 'strategy' => 'rw']);
+    $strategy = Strategy::create(['name' => 'CLI reviewed policy', 'enabled' => true]);
+    $device = impactDevice('981000014');
+
+    $this->withHeaders(['Authorization' => "Bearer {$plain}"])
+        ->post('/api/devices/cli', [
+            'id' => $device->rustdesk_id,
+            'uuid' => $device->uuid,
+            'strategy_name' => $strategy->name,
+        ])
+        ->assertStatus(409)
+        ->assertSee('reviewed impact confirmation');
+
+    expect($device->fresh()->assignedStrategyId())->toBeNull();
+});
+
+it('keeps fleet assignments and device samples admin-only', function () {
+    $role = Role::create(['name' => 'Strategy manager', 'permissions' => ['strategy' => 'rw']]);
+    $manager = User::factory()->create(['is_admin' => false, 'role_id' => $role->id]);
+    $strategy = Strategy::create(['name' => 'Delegated policy', 'enabled' => true]);
+    $hidden = impactDevice('981000010');
+    Strategy::assignTo(Strategy::LEVEL_DEVICE, $hidden->id, $strategy->id);
+
+    Livewire::actingAs($manager)
+        ->test(StrategyList::class)
+        ->call('openAssign', $strategy->id)
+        ->assertForbidden();
+
+    Livewire::actingAs($manager)
+        ->test(StrategyList::class)
+        ->call('edit', $strategy->id)
+        ->set('formOptions.enable-audio', 'N')
+        ->call('previewSave')
+        ->assertSet('impactPreview.affected_count', 1)
+        ->assertSet('impactPreview.affected_devices', [])
+        ->assertDontSee('981000010');
+});
+
+it('requires strategy permission when a console owner change alters effective policy', function () {
+    $role = Role::create(['name' => 'Device manager', 'permissions' => ['device' => 'rw']]);
+    $manager = User::factory()->create(['is_admin' => false, 'role_id' => $role->id]);
+    $newOwner = User::factory()->create();
+    $fallback = Strategy::create(['name' => 'Console fallback', 'enabled' => true, 'is_default' => true]);
+    $ownerPolicy = Strategy::create(['name' => 'Console owner policy', 'enabled' => true]);
+    Strategy::assignTo(Strategy::LEVEL_USER, $newOwner->id, $ownerPolicy->id);
+    $group = DeviceGroup::create(['name' => 'Managed devices']);
+    GroupAccess::create([
+        'accessor_type' => GroupAccess::ACCESSOR_USER,
+        'accessor_id' => $manager->id,
+        'target_type' => GroupAccess::TARGET_DEVICE_GROUP,
+        'target_id' => $group->id,
+    ]);
+    $device = impactDevice('981000012', ['user_id' => $manager->id, 'device_group_id' => $group->id]);
+
+    Livewire::actingAs($manager)
+        ->test(DeviceList::class)
+        ->call('edit', $device->id)
+        ->set('formUserId', $newOwner->id)
+        ->call('save')
+        ->assertForbidden();
+
+    expect($device->fresh()->user_id)->toBe($manager->id)
+        ->and($device->fresh()->strategy_id_resolved)->toBe($fallback->id);
+});
+
+it('blocks direct strategy assignment in the device editor in favor of reviewed fleet assignment', function () {
+    $admin = impactAdmin();
+    $strategy = Strategy::create(['name' => 'Reviewed assignment only', 'enabled' => true]);
+    $device = impactDevice('981000013');
+
+    Livewire::actingAs($admin)
+        ->test(DeviceList::class)
+        ->call('edit', $device->id)
+        ->set('formStrategyId', $strategy->id)
+        ->call('save')
+        ->assertHasErrors('formStrategyId');
+
+    expect($device->assignedStrategyId())->toBeNull();
+});
+
+it('removes soft-deleted device assignments exactly as previewed', function () {
+    $admin = impactAdmin();
+    $strategy = Strategy::create(['name' => 'Soft-deleted assignment', 'enabled' => true]);
+    $device = impactDevice('981000015');
+    Strategy::assignTo(Strategy::LEVEL_DEVICE, $device->id, $strategy->id);
+    Device::deleteWithStrategyContext($device);
+
+    Livewire::actingAs($admin)->test(StrategyList::class)
+        ->call('openAssign', $strategy->id)
+        ->call('previewAssign')
+        ->assertSet('assignmentImpact.assignment_changes.device.removed_count', 1)
+        ->call('confirmAssign')
+        ->assertHasNoErrors();
+
+    expect(DB::table('device_strategy')->where('device_id', $device->id)->exists())->toBeFalse();
+});
+
+it('confirms a reviewed assignment without changing existing editor behavior', function () {
+    $admin = impactAdmin();
+    $strategy = Strategy::create(['name' => 'Confirmed assignment', 'enabled' => true]);
+    $device = impactDevice('981000007');
+
+    Livewire::actingAs($admin)
+        ->test(StrategyList::class)
+        ->call('openAssign', $strategy->id)
+        ->set('assignDeviceIds', [$device->id])
+        ->call('previewAssign')
+        ->call('confirmAssign')
+        ->assertHasNoErrors()
+        ->assertSet('assigningId', null);
+
+    expect($device->fresh()->assignedStrategyId())->toBe($strategy->id);
+});

--- a/tests/Feature/StrategyRevisionHistoryTest.php
+++ b/tests/Feature/StrategyRevisionHistoryTest.php
@@ -56,6 +56,8 @@ it('creates a revision whenever the editor saves a strategy', function () {
         ->set('formName', 'Editor policy')
         ->set('formOptions.enable-file-transfer', 'N')
         ->call('save')
+        ->assertSet('previewing', true)
+        ->call('confirmSave')
         ->assertHasNoErrors();
 
     $strategy = Strategy::query()->where('name', 'Editor policy')->firstOrFail();
@@ -82,7 +84,13 @@ it('compares revisions and restores a historical snapshot as a new revision', fu
         'key' => 'options.enable-file-transfer', 'before' => 'N', 'after' => 'Y',
     ]);
 
-    $component->call('restoreRevision', $first->id)->assertHasNoErrors();
+    $component->call('restoreRevision', $first->id)
+        ->assertSet('previewing', true)
+        ->assertHasNoErrors();
+
+    expect($strategy->fresh()->optionMap())->toBe(['enable-file-transfer' => 'Y']);
+
+    $component->call('confirmSave')->assertHasNoErrors();
 
     expect($strategy->fresh()->optionMap())->toBe(['enable-file-transfer' => 'N'])
         ->and($strategy->revisions()->pluck('revision')->all())->toBe([3, 2, 1]);
@@ -130,6 +138,8 @@ it('records the strategy displaced when a restore takes back default status', fu
 
     Livewire::actingAs($admin)->test(StrategyList::class)
         ->call('restoreRevision', $historicalRevision->id)
+        ->assertSet('previewing', true)
+        ->call('confirmSave')
         ->assertHasNoErrors();
 
     expect($historical->fresh()->is_default)->toBeTrue()

--- a/tests/Feature/StrategyRevisionHistoryTest.php
+++ b/tests/Feature/StrategyRevisionHistoryTest.php
@@ -1,0 +1,288 @@
+<?php
+
+use App\Livewire\StrategyList;
+use App\Models\Strategy;
+use App\Models\StrategyRevision;
+use App\Models\User;
+use Illuminate\Database\QueryException;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Schema;
+use Livewire\Livewire;
+
+it('captures an immutable first revision for a strategy', function () {
+    $strategy = Strategy::create([
+        'name' => 'Locked down',
+        'enabled' => true,
+        'options' => ['enable-file-transfer' => 'N'],
+    ]);
+
+    $revision = StrategyRevision::capture($strategy, null, 'Initial policy');
+
+    expect(Schema::hasTable('strategy_revisions'))->toBeTrue()
+        ->and($revision->revision)->toBe(1)
+        ->and($revision->snapshot)->toMatchArray([
+            'name' => 'Locked down',
+            'options' => ['enable-file-transfer' => 'N'],
+        ])
+        ->and(fn () => $revision->update(['change_note' => 'Tampered']))
+        ->toThrow(LogicException::class)
+        ->and(fn () => $revision->delete())
+        ->toThrow(LogicException::class);
+});
+
+it('retains revision evidence and the creator name after related rows are deleted', function () {
+    $author = User::factory()->admin()->create();
+    $authorName = $author->username;
+    $strategy = Strategy::create(['name' => 'Retained history', 'enabled' => true]);
+    $revision = StrategyRevision::capture($strategy, $author->id, 'Initial');
+
+    $author->delete();
+    $strategy->delete();
+
+    expect($revision->fresh()->created_by)->toBeNull()
+        ->and($revision->fresh()->created_by_name)->toBe($authorName)
+        ->and(Strategy::find($strategy->id))->toBeNull()
+        ->and(Strategy::withTrashed()->find($strategy->id)?->trashed())->toBeTrue()
+        ->and(StrategyRevision::find($revision->id))->not->toBeNull();
+});
+
+it('creates a revision whenever the editor saves a strategy', function () {
+    $admin = User::factory()->admin()->create();
+
+    Livewire::actingAs($admin)
+        ->test(StrategyList::class)
+        ->call('create')
+        ->set('formName', 'Editor policy')
+        ->set('formOptions.enable-file-transfer', 'N')
+        ->call('save')
+        ->assertHasNoErrors();
+
+    $strategy = Strategy::query()->where('name', 'Editor policy')->firstOrFail();
+
+    expect($strategy->revisions()->count())->toBe(1)
+        ->and($strategy->active_revision_id)->toBe($strategy->revisions()->value('id'));
+});
+
+it('compares revisions and restores a historical snapshot as a new revision', function () {
+    $admin = User::factory()->admin()->create();
+    $strategy = Strategy::create(['name' => 'Rollback policy', 'enabled' => true]);
+    $first = StrategyRevision::captureSnapshot($strategy, [...$strategy->snapshot(), 'options' => ['enable-file-transfer' => 'N']], $admin->id, 'First');
+    $strategy->setOptions(['enable-file-transfer' => 'Y']);
+    $strategy->save();
+    $second = StrategyRevision::capture($strategy, $admin->id, 'Second');
+    $strategy->forceFill(['active_revision_id' => $second->id])->saveQuietly();
+
+    $component = Livewire::actingAs($admin)->test(StrategyList::class)
+        ->call('showHistory', $strategy->id)
+        ->set('compareFromRevisionId', $first->id)
+        ->set('compareToRevisionId', $second->id);
+
+    expect($component->get('revisionComparison'))->toContain([
+        'key' => 'options.enable-file-transfer', 'before' => 'N', 'after' => 'Y',
+    ]);
+
+    $component->call('restoreRevision', $first->id)->assertHasNoErrors();
+
+    expect($strategy->fresh()->optionMap())->toBe(['enable-file-transfer' => 'N'])
+        ->and($strategy->revisions()->pluck('revision')->all())->toBe([3, 2, 1]);
+});
+
+it('renders revision history and comparison controls in the strategy UI', function () {
+    $admin = User::factory()->admin()->create();
+    $strategy = Strategy::create(['name' => 'Visible history', 'enabled' => true]);
+    StrategyRevision::capture($strategy, $admin->id, 'Initial');
+
+    Livewire::actingAs($admin)
+        ->test(StrategyList::class)
+        ->call('showHistory', $strategy->id)
+        ->assertSee('Visible history revision history')
+        ->assertSeeHtml('id="compare-from"')
+        ->assertSee('Restoring creates a new revision');
+});
+
+it('allocates sequential revision numbers and keeps their database identity unique', function () {
+    $strategy = Strategy::create(['name' => 'Serialized capture', 'enabled' => true]);
+
+    $one = StrategyRevision::capture($strategy, null, 'One');
+    $two = StrategyRevision::capture($strategy, null, 'Two');
+
+    expect([$one->revision, $two->revision])->toBe([1, 2])
+        ->and(fn () => DB::table('strategy_revisions')->insert([
+            'strategy_id' => $strategy->id,
+            'revision' => 2,
+            'snapshot' => '{}',
+            'affected_devices' => 0,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]))->toThrow(QueryException::class);
+});
+
+it('records the strategy displaced when a restore takes back default status', function () {
+    $admin = User::factory()->admin()->create();
+    $historical = Strategy::create(['name' => 'Historical default', 'enabled' => true, 'is_default' => true]);
+    $historicalRevision = StrategyRevision::capture($historical, $admin->id, 'Was default');
+    $historical->forceFill(['active_revision_id' => $historicalRevision->id])->saveQuietly();
+
+    $current = Strategy::create(['name' => 'Current default', 'enabled' => true, 'is_default' => true]);
+    $currentRevision = StrategyRevision::capture($current, $admin->id, 'Current default');
+    $current->forceFill(['active_revision_id' => $currentRevision->id])->saveQuietly();
+
+    Livewire::actingAs($admin)->test(StrategyList::class)
+        ->call('restoreRevision', $historicalRevision->id)
+        ->assertHasNoErrors();
+
+    expect($historical->fresh()->is_default)->toBeTrue()
+        ->and($current->fresh()->is_default)->toBeFalse()
+        ->and($current->revisions()->count())->toBe(2)
+        ->and($current->revisions()->first()->snapshot['is_default'])->toBeFalse();
+});
+
+it('backfills valid legacy strategies and rolls the history schema back cleanly', function () {
+    $path = database_path('strategy-revision-history-test.sqlite');
+    File::delete($path);
+    File::put($path, '');
+    config(['database.connections.revision_history' => [
+        'driver' => 'sqlite', 'database' => $path, 'prefix' => '', 'foreign_key_constraints' => true,
+    ]]);
+    DB::purge('revision_history');
+    $previous = config('database.default');
+    config(['database.default' => 'revision_history']);
+
+    try {
+        Schema::create('users', fn ($table) => $table->id());
+        Schema::create('strategies', function ($table): void {
+            $table->id();
+            $table->string('name');
+            $table->string('note')->nullable();
+            $table->boolean('enabled');
+            $table->boolean('is_default');
+            $table->boolean('enforce');
+            $table->json('options')->nullable();
+            $table->timestamps();
+        });
+        Schema::create('devices', function ($table): void {
+            $table->id();
+            $table->foreignId('strategy_id_resolved')->nullable();
+        });
+        DB::table('strategies')->insert([
+            'name' => 'Legacy policy', 'enabled' => true, 'is_default' => false, 'enforce' => false,
+            'options' => json_encode(['enable-file-transfer' => 'N']), 'created_at' => now(), 'updated_at' => now(),
+        ]);
+
+        $migration = require database_path('migrations/2026_08_24_000010_create_strategy_revision_history.php');
+        $migration->up();
+
+        expect(Schema::hasTable('strategy_revisions'))->toBeTrue()
+            ->and(DB::table('strategy_revisions')->value('revision'))->toBe(1)
+            ->and(json_decode(DB::table('strategy_revisions')->value('snapshot'), true)['options'])->toBe(['enable-file-transfer' => 'N'])
+            ->and(DB::table('strategies')->value('active_revision_id'))->not->toBeNull();
+
+        $migration->down();
+
+        expect(Schema::hasTable('strategy_revisions'))->toBeFalse()
+            ->and(Schema::hasColumn('strategies', 'active_revision_id'))->toBeFalse()
+            ->and(Schema::hasColumn('strategies', 'deleted_at'))->toBeFalse();
+    } finally {
+        config(['database.default' => $previous]);
+        DB::purge('revision_history');
+        File::delete($path);
+    }
+});
+
+it('fails legacy preflight before making schema changes for invalid strategy options', function (string $legacyOptions) {
+    $path = database_path('strategy-revision-preflight-test.sqlite');
+    File::delete($path);
+    File::put($path, '');
+    config(['database.connections.revision_preflight' => [
+        'driver' => 'sqlite', 'database' => $path, 'prefix' => '', 'foreign_key_constraints' => true,
+    ]]);
+    DB::purge('revision_preflight');
+    $previous = config('database.default');
+    config(['database.default' => 'revision_preflight']);
+
+    try {
+        Schema::create('strategies', function ($table): void {
+            $table->id();
+            $table->string('name');
+            $table->string('note')->nullable();
+            $table->boolean('enabled');
+            $table->boolean('is_default');
+            $table->boolean('enforce');
+            $table->text('options')->nullable();
+            $table->timestamps();
+        });
+        Schema::create('devices', fn ($table) => $table->id());
+        DB::table('strategies')->insert([
+            'name' => 'Broken legacy policy', 'enabled' => true, 'is_default' => false, 'enforce' => false,
+            'options' => $legacyOptions, 'created_at' => now(), 'updated_at' => now(),
+        ]);
+
+        $migration = require database_path('migrations/2026_08_24_000010_create_strategy_revision_history.php');
+
+        expect(fn () => $migration->up())->toThrow(RuntimeException::class)
+            ->and(Schema::hasTable('strategy_revisions'))->toBeFalse()
+            ->and(Schema::hasColumn('strategies', 'deleted_at'))->toBeFalse();
+    } finally {
+        config(['database.default' => $previous]);
+        DB::purge('revision_preflight');
+        File::delete($path);
+    }
+})->with([
+    'malformed json' => '{not-json}',
+    'false' => 'false',
+    'zero' => '0',
+    'empty string value' => '""',
+    'null' => 'null',
+    'list-shaped options' => '["N"]',
+]);
+
+it('remains retryable after legacy preflight rejects a row', function () {
+    $path = database_path('strategy-revision-retry-test.sqlite');
+    File::delete($path);
+    File::put($path, '');
+    config(['database.connections.revision_retry' => [
+        'driver' => 'sqlite', 'database' => $path, 'prefix' => '', 'foreign_key_constraints' => true,
+    ]]);
+    DB::purge('revision_retry');
+    $previous = config('database.default');
+    config(['database.default' => 'revision_retry']);
+
+    try {
+        Schema::create('users', fn ($table) => $table->id());
+        Schema::create('strategies', function ($table): void {
+            $table->id();
+            $table->string('name');
+            $table->string('note')->nullable();
+            $table->boolean('enabled');
+            $table->boolean('is_default');
+            $table->boolean('enforce');
+            $table->text('options')->nullable();
+            $table->timestamps();
+        });
+        Schema::create('devices', function ($table): void {
+            $table->id();
+            $table->foreignId('strategy_id_resolved')->nullable();
+        });
+        $strategyId = DB::table('strategies')->insertGetId([
+            'name' => 'Retryable legacy policy', 'enabled' => true, 'is_default' => false, 'enforce' => false,
+            'options' => '{broken}', 'created_at' => now(), 'updated_at' => now(),
+        ]);
+        $migration = require database_path('migrations/2026_08_24_000010_create_strategy_revision_history.php');
+
+        expect(fn () => $migration->up())->toThrow(RuntimeException::class)
+            ->and(Schema::hasTable('strategy_revisions'))->toBeFalse()
+            ->and(Schema::hasColumn('strategies', 'active_revision_id'))->toBeFalse();
+
+        DB::table('strategies')->where('id', $strategyId)->update(['options' => '{"enable-audio":"N"}']);
+        $migration->up();
+
+        expect(Schema::hasTable('strategy_revisions'))->toBeTrue()
+            ->and(DB::table('strategy_revisions')->where('strategy_id', $strategyId)->count())->toBe(1)
+            ->and(DB::table('strategies')->where('id', $strategyId)->value('active_revision_id'))->not->toBeNull();
+    } finally {
+        config(['database.default' => $previous]);
+        DB::purge('revision_retry');
+        File::delete($path);
+    }
+});

--- a/tests/Feature/StrategyRolloutTest.php
+++ b/tests/Feature/StrategyRolloutTest.php
@@ -1,0 +1,358 @@
+<?php
+
+use App\Livewire\StrategyList;
+use App\Models\Device;
+use App\Models\Role;
+use App\Models\Strategy;
+use App\Models\StrategyRevision;
+use App\Models\StrategyRollout;
+use App\Models\User;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Validation\ValidationException;
+use Livewire\Livewire;
+
+it('installs the additive rollout foundation schema', function () {
+    expect(Schema::hasTable('strategy_rollouts'))->toBeTrue()
+        ->and(Schema::hasTable('strategy_rollout_devices'))->toBeTrue()
+        ->and(Schema::hasColumn('strategies', 'confirmation_timeout_minutes'))->toBeTrue()
+        ->and(Schema::hasColumn('devices', 'strategy_rollout_ack_pending'))->toBeTrue()
+        ->and(Schema::hasColumn('strategy_rollout_devices', 'timed_out_at'))->toBeTrue();
+});
+
+it('rolls the additive rollout foundation back in dependency-safe order', function () {
+    $migration = require database_path('migrations/2026_08_24_000020_add_strategy_rollout_foundation.php');
+
+    $migration->down();
+
+    expect(Schema::hasTable('strategy_rollout_devices'))->toBeFalse()
+        ->and(Schema::hasTable('strategy_rollouts'))->toBeFalse()
+        ->and(Schema::hasColumn('devices', 'strategy_rollout_ack_pending'))->toBeFalse()
+        ->and(Schema::hasColumn('strategies', 'confirmation_timeout_minutes'))->toBeFalse();
+});
+
+it('schedules a reviewed frozen rollout without applying the candidate globally', function () {
+    $admin = User::factory()->admin()->create();
+    $strategy = Strategy::create([
+        'name' => 'Reviewed rollout',
+        'enabled' => true,
+        'options' => ['enable-file-transfer' => 'N'],
+    ]);
+    $baseline = StrategyRevision::capture($strategy, $admin->id, 'Baseline');
+    $strategy->forceFill(['active_revision_id' => $baseline->id])->saveQuietly();
+    $device = Device::create(['rustdesk_id' => 'reviewed-rollout-device', 'uuid' => 'reviewed-rollout-device', 'status' => Device::STATUS_ACTIVE]);
+    $secondDevice = Device::create(['rustdesk_id' => 'reviewed-rollout-device-2', 'uuid' => 'reviewed-rollout-device-2', 'status' => Device::STATUS_ACTIVE]);
+    Strategy::assignTo(Strategy::LEVEL_DEVICE, $device->id, $strategy->id);
+    Strategy::assignTo(Strategy::LEVEL_DEVICE, $secondDevice->id, $strategy->id);
+
+    Livewire::actingAs($admin)->test(StrategyList::class)
+        ->call('edit', $strategy->id)
+        ->set('formOptions.enable-file-transfer', 'Y')
+        ->call('save')
+        ->assertSet('previewing', true)
+        ->set('rolloutBatchSize', 1)
+        ->set('rolloutIntervalMinutes', 5)
+        ->call('scheduleRollout')
+        ->assertHasNoErrors();
+
+    $rollout = StrategyRollout::query()->with('revision')->sole();
+    expect($strategy->fresh()->optionMap())->toBe(['enable-file-transfer' => 'N'])
+        ->and($rollout->target_count)->toBe(2)
+        ->and($rollout->targets()->whereNotNull('released_at')->count())->toBe(1)
+        ->and($rollout->revision->snapshot['options'])->toBe(['enable-file-transfer' => 'Y'])
+        ->and($strategy->fresh()->active_revision_id)->not->toBe($rollout->revision->id);
+});
+
+it('rejects apply-now policy changes while a rollout is open', function () {
+    $admin = User::factory()->admin()->create();
+    $strategy = Strategy::create(['name' => 'Locked policy', 'enabled' => true, 'options' => ['enable-file-transfer' => 'N']]);
+    $candidate = StrategyRevision::captureSnapshot($strategy, [...$strategy->snapshot(), 'options' => ['enable-file-transfer' => 'Y']], $admin->id, 'Candidate');
+    $device = Device::create(['rustdesk_id' => 'locked-policy-device', 'uuid' => 'locked-policy-device', 'status' => Device::STATUS_ACTIVE]);
+    StrategyRollout::schedule($strategy, $candidate, [$device->id], now()->addHour(), 1, 5, $admin->id);
+
+    Livewire::actingAs($admin)->test(StrategyList::class)
+        ->call('edit', $strategy->id)
+        ->set('formOptions.enable-file-transfer', 'Y')
+        ->call('save')
+        ->assertSet('previewing', true)
+        ->call('confirmSave')
+        ->assertHasErrors('strategy');
+
+    expect($strategy->fresh()->optionMap())->toBe(['enable-file-transfer' => 'N']);
+});
+
+it('rejects apply-now mutations of a different strategy while a rollout is open', function () {
+    $admin = User::factory()->admin()->create();
+    $rolling = Strategy::create(['name' => 'Rolling policy', 'enabled' => true]);
+    $candidate = StrategyRevision::capture($rolling, $admin->id, 'Candidate');
+    $target = Device::create([
+        'rustdesk_id' => 'cross-policy-target',
+        'uuid' => 'cross-policy-target',
+        'status' => Device::STATUS_ACTIVE,
+    ]);
+    StrategyRollout::schedule($rolling, $candidate, [$target->id], now()->addHour(), 1, 5, $admin->id);
+
+    $other = Strategy::create([
+        'name' => 'Different precedence policy',
+        'enabled' => false,
+        'options' => ['enable-file-transfer' => 'N'],
+    ]);
+
+    Livewire::actingAs($admin)->test(StrategyList::class)
+        ->call('edit', $other->id)
+        ->set('formEnabled', true)
+        ->call('save')
+        ->assertSet('previewing', true)
+        ->call('confirmSave')
+        ->assertHasErrors('strategy');
+
+    expect($other->fresh()->enabled)->toBeFalse();
+});
+
+it('rejects implicitly active device creation while a rollout is open', function () {
+    $strategy = Strategy::create(['name' => 'Frozen default-active fleet', 'enabled' => true]);
+    $candidate = StrategyRevision::capture($strategy, null, 'Candidate');
+    $target = Device::create([
+        'rustdesk_id' => 'existing-active-target',
+        'uuid' => 'existing-active-target',
+        'status' => Device::STATUS_ACTIVE,
+    ]);
+    StrategyRollout::schedule($strategy, $candidate, [$target->id], now()->addHour(), 1, 5, null);
+
+    expect(fn () => Device::updateWithStrategyContext(new Device, [
+        'rustdesk_id' => 'implicit-active-device',
+        'uuid' => '',
+    ]))->toThrow(ValidationException::class);
+
+    expect(Device::query()->where('rustdesk_id', 'implicit-active-device')->exists())->toBeFalse();
+});
+
+it('keeps fleet-wide rollout controls admin-only', function () {
+    $role = Role::create(['name' => 'Strategy editor', 'permissions' => ['strategy' => 'rw']]);
+    $editor = User::factory()->create(['is_admin' => false, 'role_id' => $role->id]);
+    $strategy = Strategy::create(['name' => 'Hidden rollout controls', 'enabled' => true]);
+    $candidate = StrategyRevision::capture($strategy, null, 'Candidate');
+    $device = Device::create(['rustdesk_id' => 'admin-rollout-device', 'uuid' => 'admin-rollout-device', 'status' => Device::STATUS_ACTIVE]);
+    StrategyRollout::schedule($strategy, $candidate, [$device->id], now()->addHour(), 1, 5, null);
+
+    Livewire::actingAs($editor)->test(StrategyList::class)
+        ->assertDontSee('Recent staged rollouts')
+        ->call('scheduleRollout')
+        ->assertForbidden();
+});
+
+it('freezes scheduled rollout targets in stable device order', function () {
+    $strategy = Strategy::create(['name' => 'Frozen policy', 'enabled' => true]);
+    $revision = StrategyRevision::capture($strategy, null, 'Staged candidate');
+    $second = Device::create(['rustdesk_id' => 'rollout-2', 'uuid' => 'rollout-2']);
+    $first = Device::create(['rustdesk_id' => 'rollout-1', 'uuid' => 'rollout-1']);
+
+    $rollout = StrategyRollout::schedule(
+        $strategy,
+        $revision,
+        [$second->id, $first->id, $second->id],
+        Carbon::now()->addMinute(),
+        25,
+        15,
+        null,
+    );
+
+    expect($rollout->status)->toBe(StrategyRollout::STATUS_SCHEDULED)
+        ->and($rollout->targets()->orderBy('position')->pluck('device_id')->all())->toBe([$second->id, $first->id])
+        ->and($rollout->targets()->orderBy('position')->pluck('device_rustdesk_id')->all())->toBe(['rollout-2', 'rollout-1']);
+});
+
+it('starts a due rollout and releases one bounded batch', function () {
+    Carbon::setTestNow('2026-08-24 12:00:00');
+    $strategy = Strategy::create(['name' => 'Batched policy', 'enabled' => true]);
+    $revision = StrategyRevision::capture($strategy, null, 'Candidate');
+    $devices = collect(range(1, 3))->map(fn (int $id) => Device::create(['rustdesk_id' => "batch-{$id}", 'uuid' => "batch-{$id}"]));
+    $rollout = StrategyRollout::schedule($strategy, $revision, $devices->pluck('id')->all(), now()->addMinute(), 2, 10, null);
+
+    Carbon::setTestNow(now()->addMinute());
+    expect(StrategyRollout::advanceDue())->toBe(1)
+        ->and($rollout->fresh()->status)->toBe(StrategyRollout::STATUS_ACTIVE)
+        ->and($rollout->targets()->whereNotNull('released_at')->count())->toBe(2)
+        ->and($rollout->fresh()->next_release_at?->format('Y-m-d H:i:s'))->toBe('2026-08-24 12:11:00');
+
+    Carbon::setTestNow();
+});
+
+it('releases the first bounded batch immediately when a rollout starts now', function () {
+    Carbon::setTestNow('2026-08-24 12:30:00');
+    $strategy = Strategy::create(['name' => 'Immediate policy', 'enabled' => true]);
+    $revision = StrategyRevision::capture($strategy, null, 'Candidate');
+    $devices = collect(range(1, 3))->map(fn (int $id) => Device::create(['rustdesk_id' => "immediate-{$id}", 'uuid' => "immediate-{$id}"]));
+
+    $rollout = StrategyRollout::schedule($strategy, $revision, $devices->pluck('id')->all(), now(), 2, 10, null);
+
+    expect($rollout->status)->toBe(StrategyRollout::STATUS_ACTIVE)
+        ->and($rollout->targets()->whereNotNull('released_at')->count())->toBe(2)
+        ->and($rollout->fresh()->next_release_at?->format('Y-m-d H:i:s'))->toBe('2026-08-24 12:40:00');
+    Carbon::setTestNow();
+});
+
+it('gates each batch and completion on confirmation or persisted timeout', function () {
+    Carbon::setTestNow('2026-08-24 12:45:00');
+    $strategy = Strategy::create(['name' => 'Confirmation-gated policy', 'enabled' => true, 'confirmation_timeout_minutes' => 15]);
+    $revision = StrategyRevision::capture($strategy, null, 'Candidate');
+    $devices = collect(range(1, 2))->map(fn (int $id) => Device::create(['rustdesk_id' => "gated-{$id}", 'uuid' => "gated-{$id}"]));
+    $rollout = StrategyRollout::schedule($strategy, $revision, $devices->pluck('id')->all(), now(), 1, 1, null);
+
+    Carbon::setTestNow(now()->addMinute());
+    expect(StrategyRollout::advanceDue())->toBe(0)
+        ->and($rollout->targets()->whereNotNull('released_at')->count())->toBe(1)
+        ->and($rollout->targets()->whereNotNull('timed_out_at')->count())->toBe(0);
+
+    Carbon::setTestNow(now()->addMinutes(14));
+    expect(StrategyRollout::advanceDue())->toBe(1)
+        ->and($rollout->targets()->whereNotNull('released_at')->count())->toBe(2)
+        ->and($rollout->targets()->whereNotNull('timed_out_at')->count())->toBe(1)
+        ->and($rollout->fresh()->status)->toBe(StrategyRollout::STATUS_ACTIVE);
+
+    Carbon::setTestNow(now()->addMinutes(15));
+    expect(StrategyRollout::advanceDue())->toBe(1)
+        ->and($rollout->fresh()->status)->toBe(StrategyRollout::STATUS_COMPLETED)
+        ->and($rollout->targets()->whereNotNull('timed_out_at')->count())->toBe(2);
+    Carbon::setTestNow();
+});
+
+it('allows cancellation only before the first batch is released', function () {
+    Carbon::setTestNow('2026-08-24 13:00:00');
+    $strategy = Strategy::create(['name' => 'Controlled rollout', 'enabled' => true]);
+    $revision = StrategyRevision::capture($strategy, null, 'Candidate');
+    $devices = collect(range(1, 2))->map(fn (int $id) => Device::create(['rustdesk_id' => "control-{$id}", 'uuid' => "control-{$id}"]));
+    $scheduled = StrategyRollout::schedule($strategy, $revision, $devices->pluck('id')->all(), now()->addHour(), 1, 10, null);
+    expect($scheduled->cancel())->toBeTrue()
+        ->and($scheduled->fresh()->status)->toBe(StrategyRollout::STATUS_CANCELLED);
+
+    $rollout = StrategyRollout::schedule($strategy, $revision, $devices->pluck('id')->all(), now(), 1, 10, null);
+    expect(fn () => $rollout->cancel())->toThrow(ValidationException::class)
+        ->and($rollout->pause(null))->toBeTrue()
+        ->and($rollout->fresh()->status)->toBe(StrategyRollout::STATUS_PAUSED)
+        ->and(fn () => $rollout->cancel())->toThrow(ValidationException::class);
+    Carbon::setTestNow();
+});
+
+it('resumes a paused rollout by releasing exactly the next batch', function () {
+    Carbon::setTestNow('2026-08-24 13:15:00');
+    $strategy = Strategy::create(['name' => 'Resumable rollout', 'enabled' => true]);
+    $revision = StrategyRevision::capture($strategy, null, 'Candidate');
+    $devices = collect(range(1, 3))->map(fn (int $id) => Device::create(['rustdesk_id' => "resume-{$id}", 'uuid' => "resume-{$id}"]));
+    $rollout = StrategyRollout::schedule($strategy, $revision, $devices->pluck('id')->all(), now(), 1, 10, null);
+    expect($rollout->pause(null))->toBeTrue();
+
+    Carbon::setTestNow(now()->addHour());
+
+    expect(StrategyRollout::advanceDue())->toBe(0)
+        ->and($rollout->targets()->whereNotNull('released_at')->count())->toBe(1)
+        ->and($rollout->resume())->toBeTrue()
+        ->and($rollout->targets()->whereNotNull('released_at')->count())->toBe(2)
+        ->and($rollout->targets()->whereNotNull('timed_out_at')->count())->toBe(1);
+    Carbon::setTestNow();
+});
+
+it('freezes active membership and every precedence writer while a rollout is open', function () {
+    $strategy = Strategy::create(['name' => 'Frozen fleet policy', 'enabled' => true]);
+    $revision = StrategyRevision::capture($strategy, null, 'Candidate');
+    $target = Device::create(['rustdesk_id' => 'frozen-target', 'uuid' => 'frozen-target', 'status' => Device::STATUS_ACTIVE]);
+    StrategyRollout::schedule($strategy, $revision, [$target->id], now()->addHour(), 1, 15, null);
+
+    $pending = Device::create(['rustdesk_id' => 'pending-approval', 'uuid' => 'pending-approval', 'status' => Device::STATUS_PENDING]);
+    expect(fn () => Device::updateWithStrategyContext($pending, ['status' => Device::STATUS_ACTIVE]))
+        ->toThrow(ValidationException::class)
+        ->and(fn () => Device::deleteWithStrategyContext($target))->toThrow(ValidationException::class);
+
+    $unrelated = Strategy::create(['name' => 'Unrelated precedence policy', 'enabled' => true]);
+    $user = User::factory()->create();
+    expect(fn () => Strategy::assignTo(Strategy::LEVEL_USER, $user->id, $unrelated->id))
+        ->toThrow(ValidationException::class);
+});
+
+it('rejects staged changes to strategy identity and resolution metadata', function () {
+    $strategy = Strategy::create(['name' => 'Stable identity', 'enabled' => true, 'confirmation_timeout_minutes' => 15]);
+    $revision = StrategyRevision::captureSnapshot(
+        $strategy,
+        [...$strategy->snapshot(), 'name' => 'Renamed candidate'],
+        null,
+        'Invalid candidate',
+    );
+    $device = Device::create(['rustdesk_id' => 'identity-1', 'uuid' => 'identity-1']);
+
+    expect(fn () => StrategyRollout::schedule($strategy, $revision, [$device->id], now()->addMinute(), 1, 15, null))
+        ->toThrow(ValidationException::class);
+});
+
+it('advances due rollouts through the scheduled command', function () {
+    Carbon::setTestNow('2026-08-24 13:30:00');
+    $strategy = Strategy::create(['name' => 'Command policy', 'enabled' => true, 'options' => ['enable-audio' => 'N']]);
+    $revision = StrategyRevision::captureSnapshot($strategy, [...$strategy->snapshot(), 'options' => ['enable-audio' => 'Y']], null, 'Candidate');
+    $device = Device::create(['rustdesk_id' => 'command-1', 'uuid' => 'command-1']);
+    Strategy::assignTo(Strategy::LEVEL_DEVICE, $device->id, $strategy->id);
+    $rollout = StrategyRollout::schedule($strategy, $revision, [$device->id], now()->addMinute(), 1, 15, null);
+
+    Carbon::setTestNow(now()->addMinute());
+
+    expect(Artisan::call('cortendesk:advance-strategy-rollouts'))->toBe(0)
+        ->and($rollout->fresh()->status)->toBe(StrategyRollout::STATUS_ACTIVE)
+        ->and($rollout->targets()->whereNotNull('released_at')->count())->toBe(1);
+
+    $message = Strategy::deliveryFor($device->fresh(), 0);
+    Strategy::deliveryFor($device->fresh(), $message['modified_at']);
+    Carbon::setTestNow(now()->addMinutes(15));
+    Artisan::call('cortendesk:advance-strategy-rollouts');
+    expect($rollout->fresh()->status)->toBe(StrategyRollout::STATUS_COMPLETED);
+    Carbon::setTestNow();
+});
+
+it('delivers a released frozen policy and confirms its echoed token', function () {
+    Carbon::setTestNow('2026-08-24 14:00:00');
+    $strategy = Strategy::create(['name' => 'Delivered policy', 'enabled' => true, 'options' => ['enable-audio' => 'N']]);
+    $revision = StrategyRevision::captureSnapshot($strategy, [...$strategy->snapshot(), 'options' => ['enable-audio' => 'Y']], null, 'Candidate');
+    $device = Device::create(['rustdesk_id' => 'delivery-1', 'uuid' => 'delivery-1']);
+    Strategy::assignTo(Strategy::LEVEL_DEVICE, $device->id, $strategy->id);
+    $rollout = StrategyRollout::schedule($strategy, $revision, [$device->id], now()->addMinute(), 1, 15, null);
+
+    Carbon::setTestNow(now()->addMinute());
+    StrategyRollout::advanceDue();
+    $response = Strategy::deliveryFor($device->fresh(), 0);
+    $token = $response['modified_at'];
+
+    expect($response['strategy']['config_options'])->toBe(['enable-audio' => 'Y'])
+        ->and($rollout->targets()->value('delivered_version'))->toBe($token)
+        ->and($device->fresh()->strategy_rollout_ack_pending)->toBeTrue();
+
+    Strategy::deliveryFor($device->fresh(), $token);
+
+    expect($rollout->targets()->value('confirmed_at'))->not->toBeNull()
+        ->and($device->fresh()->strategy_rollout_ack_pending)->toBeFalse();
+    Carbon::setTestNow();
+});
+
+it('captures confirmation timeout in revision snapshots', function () {
+    $strategy = Strategy::create(['name' => 'Timed policy', 'enabled' => true, 'confirmation_timeout_minutes' => 42]);
+
+    expect(StrategyRevision::capture($strategy, null, 'Timed')->snapshot['confirmation_timeout_minutes'])->toBe(42);
+});
+
+it('fails closed when an assignment would change an open rollout target set', function () {
+    $strategy = Strategy::create(['name' => 'Locked assignment', 'enabled' => true]);
+    $revision = StrategyRevision::capture($strategy, null, 'Candidate');
+    $device = Device::create(['rustdesk_id' => 'locked-1', 'uuid' => 'locked-1']);
+    StrategyRollout::schedule($strategy, $revision, [$device->id], now()->addMinute(), 1, 15, null);
+
+    expect(fn () => Strategy::assignTo(Strategy::LEVEL_DEVICE, $device->id, $strategy->id))
+        ->toThrow(ValidationException::class);
+});
+
+it('fails closed when an owner mutation could change an open rollout target set', function () {
+    $strategy = Strategy::create(['name' => 'Locked owner', 'enabled' => true]);
+    $revision = StrategyRevision::capture($strategy, null, 'Candidate');
+    $device = Device::create(['rustdesk_id' => 'owner-locked-1', 'uuid' => 'owner-locked-1']);
+    StrategyRollout::schedule($strategy, $revision, [$device->id], now()->addMinute(), 1, 15, null);
+    $owner = User::factory()->create();
+
+    expect(fn () => Device::updateWithStrategyContext($device, ['user_id' => $owner->id]))
+        ->toThrow(ValidationException::class);
+});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,0 +1,8 @@
+<?php
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+pest()->extend(TestCase::class)
+    ->use(RefreshDatabase::class)
+    ->in('Feature');

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Tests;
+
+use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
+
+abstract class TestCase extends BaseTestCase
+{
+    //
+}


### PR DESCRIPTION
## Summary

Part 3 of 4 replacing #61. Depends on #64.

- add immutable rollout and rollout-target evidence linked to strategy revisions
- freeze the reviewed target set and release bounded batches now or at a scheduled time
- gate every next batch and final completion on confirmation or a persisted per-target timeout
- pause/resume active rollouts and allow cancellation only before the first release
- freeze policy, assignment, owner/group, active-membership, lifecycle, implicit-active creation, and destructive-import writers while a rollout is open
- deliver released revision snapshots, persist delivery/ack evidence, and complete by activating the candidate revision
- add the `cortendesk:advance-strategy-rollouts` command and one-minute overlap-safe scheduler entry

## Migration and lock safety

- additive migration adds confirmation timeout, device rollout-ack state, rollout tables, and `timed_out_at` evidence
- rollout revisions use restrictive deletion semantics; device identity remains as immutable RustDesk-ID evidence after device deletion
- stable lock order is strategies → rollout → targets
- multiple scheduler processes re-check status and release boundaries under row locks

## Scope boundaries

- no compliance-state service or compliance UI
- no `strategy_sent_at` field (added by the reporting layer only)
- no admin API field changes
- intentionally excludes `docs/strategy-protocol.md` and the GitHub workflow

## Verification

- `php artisan test --compact` — **53 tests, 220 assertions passed**
- fresh migration + seed passed
- rollout command ran successfully; scheduler listing includes the one-minute command
- changed-file Pint check, `composer validate --strict`, and `git diff --check` passed

Per maintainer guidance, no GitHub CI workflow is added; the repository's MySQL concurrency exercise remains review-run. This is stacked; until #64 merges, GitHub will show prerequisite commits. Review commit: `f3e0c63`.
